### PR TITLE
Add GitHub action for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: quay.io/hsaunders1904/hippo:latest
-      options: --user root
-      env:
-        HOME: /root
 
     steps:
     - uses: actions/checkout@v3
@@ -28,6 +25,7 @@ jobs:
         pre-commit install
         pre-commit run --all
     - name: Build
+      shell: bash
       run: |
         ls
         ls "${HOME}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
         mkdir -p ~/.OpenFOAM
         cp ./scripts/openfoam-prefs.sh ~/.OpenFOAM/prefs.sh
 
-        # This is just exiting with this message: 'Error: Process completed with exit code 1'
         . /opt/openfoam/OpenFOAM-10/etc/bashrc || true
 
         echo "FOAM_INST_DIR: ${FOAM_INST_DIR}"
@@ -39,7 +38,9 @@ jobs:
 
         make
     - name: Test
+      shell: bash
       run: |
+        . /opt/openfoam/OpenFOAM-10/etc/bashrc || true
         # Fully expect this to fail as it requires 8 cores, but the GitHub
         # runners only have 2...
         ./run_tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+# Lint, build, and test hippo on a push to main or a pull request
+
+name: hippo-ci
+permissions: read-all
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/hippo/hippo:latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Quality Checks
+      run: |
+        pip install pre-commit
+        pre-commit install
+        pre-commit run --all
+    - name: Build
+      run: |
+        make
+    - name: Test
+      run: |
+        # Fully expect this to fail as it requires 8 cores, but the GitHub
+        # runners only have 2...
+        ./run_tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,20 +27,22 @@ jobs:
     - name: Build
       shell: bash
       run: |
+        # Copy the OpenFOAM configuration into the home directory. GitHub
+        # overrides the home directory set in the docker image.
         mkdir -p ~/.OpenFOAM
         cp ./scripts/openfoam-prefs.sh ~/.OpenFOAM/prefs.sh
 
+        # Initialise OpenFOAM
         . /opt/openfoam/OpenFOAM-10/etc/bashrc || true
 
-        echo "FOAM_INST_DIR: ${FOAM_INST_DIR}"
-        echo "WM_PROJECT_INST_DIR: ${WM_PROJECT_INST_DIR}"
-        echo "WM_PROJECT_DIR: ${WM_PROJECT_DIR}"
-
+        # Build hippo
         make
     - name: Test
       shell: bash
       run: |
+        # Initialise OpenFOAM
         . /opt/openfoam/OpenFOAM-10/etc/bashrc || true
+
         # Fully expect this to fail as it requires 8 cores, but the GitHub
         # runners only have 2...
         ./run_tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: quay.io/hippo/hippo:latest
+      credentials:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_LOGIN_TOKEN }}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,17 +27,24 @@ jobs:
     - name: Build
       shell: bash
       run: |
-        ls
-        ls "${HOME}"
         echo "User: $(whoami)"
         echo "Home: ${HOME}"
         echo "~: $(cd ~ && pwd)"
+
         mkdir -p ~/.OpenFOAM
+        ls -A "${HOME}"
+
         cp ./scripts/openfoam-prefs.sh ~/.OpenFOAM/prefs.sh
+        echo "cp ./scripts/openfoam-prefs.sh ~/.OpenFOAM/prefs.sh - OK"
+        ls -A "${HOME}"
+
+        echo "ls -l /opt/openfoam/OpenFOAM-10/etc/bashrc: $(ls -l /opt/openfoam/OpenFOAM-10/etc/bashrc)"
         . /opt/openfoam/OpenFOAM-10/etc/bashrc
+
         echo "FOAM_INST_DIR: ${FOAM_INST_DIR}"
         echo "WM_PROJECT_INST_DIR: ${WM_PROJECT_INST_DIR}"
         echo "WM_PROJECT_DIR: ${WM_PROJECT_DIR}"
+
         make
     - name: Test
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,9 @@ jobs:
         pre-commit run --all
     - name: Build
       run: |
-        ls
-        echo "User: $(whoami)"
-        echo "Home: ${HOME}"
-        echo "~: $(cd ~ && pwd)"
         mkdir -p ~/.OpenFOAM
         cp ./scripts/openfoam-prefs.sh ~/.OpenFOAM/prefs.sh
-        source /opt/openfoam/OpenFOAM-10/etc/bashrc
+        . /opt/openfoam/OpenFOAM-10/etc/bashrc
         make
     - name: Test
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,7 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/hippo/hippo:latest
-      credentials:
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_LOGIN_TOKEN }}
+      image: quay.io/hsaunders1904/hippo:latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,19 +27,11 @@ jobs:
     - name: Build
       shell: bash
       run: |
-        echo "User: $(whoami)"
-        echo "Home: ${HOME}"
-        echo "~: $(cd ~ && pwd)"
-
         mkdir -p ~/.OpenFOAM
-        ls -A "${HOME}"
-
         cp ./scripts/openfoam-prefs.sh ~/.OpenFOAM/prefs.sh
-        echo "cp ./scripts/openfoam-prefs.sh ~/.OpenFOAM/prefs.sh - OK"
-        ls -A "${HOME}"
 
-        echo "ls -l /opt/openfoam/OpenFOAM-10/etc/bashrc: $(ls -l /opt/openfoam/OpenFOAM-10/etc/bashrc)"
-        . /opt/openfoam/OpenFOAM-10/etc/bashrc
+        # This is just exiting with this message: 'Error: Process completed with exit code 1'
+        . /opt/openfoam/OpenFOAM-10/etc/bashrc || true
 
         echo "FOAM_INST_DIR: ${FOAM_INST_DIR}"
         echo "WM_PROJECT_INST_DIR: ${WM_PROJECT_INST_DIR}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: quay.io/hsaunders1904/hippo:latest
+      options: --user root
+      env:
+        HOME: /root
 
     steps:
     - uses: actions/checkout@v3
@@ -26,9 +29,17 @@ jobs:
         pre-commit run --all
     - name: Build
       run: |
+        ls
+        ls "${HOME}"
+        echo "User: $(whoami)"
+        echo "Home: ${HOME}"
+        echo "~: $(cd ~ && pwd)"
         mkdir -p ~/.OpenFOAM
         cp ./scripts/openfoam-prefs.sh ~/.OpenFOAM/prefs.sh
         . /opt/openfoam/OpenFOAM-10/etc/bashrc
+        echo "FOAM_INST_DIR: ${FOAM_INST_DIR}"
+        echo "WM_PROJECT_INST_DIR: ${WM_PROJECT_INST_DIR}"
+        echo "WM_PROJECT_DIR: ${WM_PROJECT_DIR}"
         make
     - name: Test
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,13 @@ jobs:
         pre-commit run --all
     - name: Build
       run: |
+        ls
+        echo "User: $(whoami)"
+        echo "Home: ${HOME}"
+        echo "~: $(cd ~ && pwd)"
+        mkdir -p ~/.OpenFOAM
+        cp ./scripts/openfoam-prefs.sh ~/.OpenFOAM/prefs.sh
+        source /opt/openfoam/OpenFOAM-10/etc/bashrc
         make
     - name: Test
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ jobs:
     - uses: actions/checkout@v3
     - name: Quality Checks
       run: |
+        # As we're running in our own container, we're not the same user as is
+        # used by 'actions/checkout', so git operations fail.
+        # https://github.com/actions/checkout/issues/766
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
         pip install pre-commit
         pre-commit install
         pre-commit run --all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,5 @@ jobs:
     - name: Test
       shell: bash
       run: |
-        # Initialise OpenFOAM
         . /opt/openfoam/OpenFOAM-10/etc/bashrc || true
-
-        # Fully expect this to fail as it requires 8 cores, but the GitHub
-        # runners only have 2...
         ./run_tests

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Created by 'scripts/install-openfoam.sh'
 external/*
+hippo.yaml
 
 # MOOSE ignores:
 .libs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,3 @@ repos:
     hooks:
       - id: remove-crlf
       - id: forbid-tabs
-  - repo: https://github.com/hadolint/hadolint.git
-    rev: v2.12.0
-    hooks:
-      - id: hadolint

--- a/include/base/FoamInterface.h
+++ b/include/base/FoamInterface.h
@@ -75,4 +75,3 @@ public:
   Foam::Field<double> interpolateFaceToNode(int patch_id, Foam::fvPatchField<double> const & field);
 };
 }
-

--- a/scripts/openfoam.patch
+++ b/scripts/openfoam.patch
@@ -1,24 +1,3 @@
-diff --git a/etc/bashrc b/etc/bashrc
-index 663993951..258b8fcbb 100644
---- a/etc/bashrc
-+++ b/etc/bashrc
-@@ -81,12 +81,14 @@ export WM_LABEL_SIZE=32
-
- #- Optimised, debug, profiling:
- #    WM_COMPILE_OPTION = Opt | Debug | Prof
--export WM_COMPILE_OPTION=Opt
-+export WM_COMPILE_OPTION=Debug
-
- #- MPI implementation:
- #    WM_MPLIB = SYSTEMOPENMPI | OPENMPI | SYSTEMMPI | MPICH | MPICH-GM | HPMPI
- #               | MPI | FJMPI | QSMPI | SGIMPI | INTELMPI
--export WM_MPLIB=SYSTEMOPENMPI
-+#export WM_MPLIB=SYSTEMOPENMPI
-+export WM_MPLIB=SYSTEMMPI
-+
-
- #- Operating System:
- #    WM_OSTYPE = POSIX | ???
 diff --git a/src/OpenFOAM/db/IOstreams/Pstreams/UPstream.H b/src/OpenFOAM/db/IOstreams/Pstreams/UPstream.H
 index 3bc4fa20a..e560ba081 100644
 --- a/src/OpenFOAM/db/IOstreams/Pstreams/UPstream.H


### PR DESCRIPTION
## Summary

<!-- Describe the changes that this pull request makes. -->
Adds GitHub action for CI. The workflow uses the docker image hosted on Quay.io, so we don't need to build OpenFOAM every time. It runs the pre-commit linting checks, builds hippo, and runs the simple tests (which I expect - for the moment - to fail, due to the GitHub runners having an insufficient number of cores).