### PR TITLE
Fix input variable access in docker-deploy action

### DIFF
--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -28,4 +28,4 @@ jobs:
         with:
           push: true
           file: ./docker/Dockerfile
-          tags: quay.io/hsaunders1904/hippo:${{ github.event.inputs.version }}
+          tags: quay.io/hsaunders1904/hippo:${{ github.event.inputs.tag }}


### PR DESCRIPTION
## Summary

<!-- Describe the changes that this pull request makes. -->
Fixes the misnamed input variable access in the docker-deploy workflow. 

This workflow is now working, and we have a [successful build and push](https://github.com/aurora-multiphysics/hippo/actions/runs/6327496756) to Quay.io 🎉 
