### PR TITLE
Fix bug in OpenFOAM patch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,9 +14,13 @@ repos:
         args: [--unsafe]
       - id: detect-private-key
       - id: end-of-file-fixer
+        exclude_types:
+          - "diff"
       - id: mixed-line-ending
       - id: no-commit-to-branch
       - id: trailing-whitespace
+        exclude_types:
+          - "diff"
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.4
     hooks:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,15 @@ COPY ./scripts/install-openfoam.sh ./scripts/install-openfoam.sh
 COPY ./scripts/openfoam.patch ./scripts/openfoam.patch
 COPY ./scripts/openfoam-prefs.sh /root/.OpenFOAM/prefs.sh
 
+ENV MOOSE_DIR=/opt/moose
+ENV MPI_ROOT=/usr/local
+ENV MPI_ARCH_INC="-I/usr/local/include"
+ENV MPI_ARCH_LIBS="-L/usr/local/lib -lmpi"
+ENV CC=/usr/local/bin/mpicc
+ENV CXX=/usr/local/bin/mpicxx
+ENV F77=/usr/local/bin/mpif77
+ENV F90=/usr/local/bin/mpif90
+
 RUN DEBIAN_FRONTEND=noninteractive \
     # Install OpenFOAM build dependencies
     apt-get update && \
@@ -49,5 +58,4 @@ RUN DEBIAN_FRONTEND=noninteractive \
     && \
     rm -rf /var/lib/apt/lists/*
 
-ENV MOOSE_DIR=/opt/moose
 ENTRYPOINT ["/bin/bash", "-c", "source /opt/openfoam/OpenFOAM-10/etc/bashrc && \"$@\"", "-s"]

--- a/scripts/install-openfoam.sh
+++ b/scripts/install-openfoam.sh
@@ -19,7 +19,6 @@ You can do this by running:
         libqt5x11extras5-dev \\
         libxt-dev \\
         make \\
-        mpich \\
         paraview \\
         paraview-dev \\
         qtbase5-dev \\

--- a/scripts/install-openfoam.sh
+++ b/scripts/install-openfoam.sh
@@ -12,10 +12,13 @@ Note that you will need to install OpenFOAM's requirements separately.
 You can do this by running:
 
     apt install \\
+        bison \\
         flex \\
+        libptscotch-dev \\
         libqt5opengl5-dev \\
         libqt5x11extras5-dev \\
         libxt-dev \\
+        make \\
         mpich \\
         paraview \\
         paraview-dev \\
@@ -79,7 +82,7 @@ wget -O - http://dl.openfoam.org/third-party/10 | tar xvz
 mv "ThirdParty-10-version-10" "${THIRDPARTY_DIR}"
 (
     cd "${THIRDPARTY_DIR}" \
-    && echo ./Allwmake
+    && ./Allwmake
 )
 
 # Refresh OpenFOAM paths

--- a/scripts/openfoam.patch
+++ b/scripts/openfoam.patch
@@ -277,7 +277,7 @@ index f0553baee..95a67396d 100644
 @@ -42,6 +42,15 @@ bool Foam::UPstream::init(int& argc, char**& argv, const bool needsThread)
      return false;
  }
- 
+
 +bool Foam::UPstream::init(void *, bool needsThread) {
 +    FatalErrorInFunction
 +        << "Trying to use the dummy Pstream library." << nl
@@ -287,11 +287,11 @@ index f0553baee..95a67396d 100644
 +    return false;
 +}
 +
- 
+
  void Foam::UPstream::exit(int errnum)
  {
 diff --git a/src/Pstream/mpi/UPstream.C b/src/Pstream/mpi/UPstream.C
-index 03433b398..d0821ae8c 100644
+index 03433b398..dc9e39c0b 100644
 --- a/src/Pstream/mpi/UPstream.C
 +++ b/src/Pstream/mpi/UPstream.C
 @@ -50,6 +50,7 @@ License
@@ -405,14 +405,16 @@ index 03433b398..d0821ae8c 100644
 
 
  bool Foam::UPstream::init(int& argc, char**& argv, const bool needsThread)
-@@ -185,7 +282,9 @@ void Foam::UPstream::exit(int errnum)
+@@ -185,8 +282,10 @@ void Foam::UPstream::exit(int errnum)
 
      if (errnum == 0)
      {
 -        MPI_Finalize();
+-        ::exit(errnum);
 +        if (!_external_mpi) {
 +            MPI_Finalize();
++            ::exit(errnum);
 +        }
-         ::exit(errnum);
      }
      else
+     {


### PR DESCRIPTION
## Summary

<!-- Describe the changes that this pull request makes. -->
Update the OpenFOAM patch to make sure MPI processes are not terminated within OpenFOAM, when they should be being terminated by MOOSE.

Also adds a few build flags to the Dockerfile to make sure we're using the right MPI.

