### PR TITLE
Skip no-commit-to-branch pre-commit check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
         pip install pre-commit
         pre-commit install
-        pre-commit run --all
+        SKIP=no-commit-to-branch pre-commit run --all
     - name: Build
       shell: bash
       run: |


### PR DESCRIPTION
## Summary

This causes issues when the CI is run on a push to main, as the no-commit-to-branch check will always fail.

This hook is really to prevent developers committing directly to main locally. We can safely skip it in our CI, as branch protections will prevent new commits being pushed to main.


<!-- Describe the changes that this pull request makes. -->
