### PR TITLE
Fix error when running parallel test twice

### DIFF
--- a/test/tests/simple_multiapp/par/tests
+++ b/test/tests/simple_multiapp/par/tests
@@ -2,7 +2,7 @@
   [temperature_set_on_openfoam_boundary_in_parallel]
     [run]
       type = RunCommand
-      command = '(cd buoyantCavity && decomposePar) && ./run.sh ../../../../hippo-opt'
+      command = '(cd buoyantCavity && decomposePar -force) && ./run.sh ../../../../hippo-opt'
     []
     [verify]
       type = PythonUnitTest


### PR DESCRIPTION
## Summary

<!-- Describe the changes that this pull request makes. -->
OpenFOAM complains when you try to run `decomposePar` on a case that is already decomposed. Which meant the parallel version of the 'simple_multiapp' test would fail the second time it is run. Add the '-force' flag to `decomposePar` to fix this.

