### PR TITLE
Build heat conduction module into docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
         # used by 'actions/checkout', so git operations fail.
         # https://github.com/actions/checkout/issues/766
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        pip install pre-commit
         pre-commit install
         SKIP=no-commit-to-branch pre-commit run --all
     - name: Build
@@ -40,6 +39,5 @@ jobs:
     - name: Test
       shell: bash
       run: |
-        python -m pip install "fluidfoam>=0.2.4"
         . /opt/openfoam/OpenFOAM-10/etc/bashrc || true
         ./run_tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/hsaunders1904/hippo:latest
+      image: quay.io/ukaea/hippo:latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       image: quay.io/hsaunders1904/hippo:latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Quality Checks
       run: |
         # As we're running in our own container, we're not the same user as is

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -24,7 +24,7 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_LOGIN_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: true
           file: ./docker/Dockerfile

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Log in to Quay.io
         uses: docker/login-action@v3
         with:
-          registry: quay.io
+          registry: quay.io/ukaea/hippo
           username: ${{ secrets.QUAY_ID }}
           password: ${{ secrets.QUAY_TOKEN }}
       - name: Build and push

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -21,8 +21,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_LOGIN_TOKEN }}
+          username: ${{ secrets.QUAY_ID }}
+          password: ${{ secrets.QUAY_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -28,4 +28,4 @@ jobs:
         with:
           push: true
           file: ./docker/Dockerfile
-          tags: quay.io/hsaunders1904/hippo:${{ github.event.inputs.tag }}
+          tags: quay.io/ukaea/hippo:${{ github.event.inputs.tag }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Hippo ignores:
+doc/html
 
 # Created by 'scripts/install-openfoam.sh'
 external/*

--- a/doc/config.yml
+++ b/doc/config.yml
@@ -15,6 +15,7 @@ Renderer:
 Extensions:
     MooseDocs.extensions.navigation:
         name: hippo
+        repo: https://github.com/aurora-multiphysics/hippo/
     MooseDocs.extensions.appsyntax:
         executable: ${ROOT_DIR}
         remove: !include ${MOOSE_DIR}/framework/doc/remove.yml

--- a/doc/content/developer_guide.md
+++ b/doc/content/developer_guide.md
@@ -1,0 +1,19 @@
+# Developer Guide
+
+This page contains information to aid in development of Hippo.
+
+## Docker
+
+The Dockerfile `docker/Dockerfile` contains the build definition for
+Hippo's CI environment.
+This environment does not contain Hippo itself,
+as it is used for testing the build.
+
+### Quay.io
+
+The built docker image is stored under
+[UKAEA's Quay.io organisation](https://quay.io/repository/ukaea/hippo).
+A [robot account](https://docs.quay.io/glossary/robot-accounts.html)
+has been set up with write permissions for the Hippo repository.
+This robot account is used to authenticate between Quay and GitHub.
+Contact UKAEA's Quay.io admins (or the RSE team) for support with this account.

--- a/doc/content/index.md
+++ b/doc/content/index.md
@@ -1,3 +1,13 @@
 !config navigation breadcrumbs=False scrollspy=False
 
-# hippoApp
+# Hippo
+
+A MOOSE multiapp wrapping OpenFOAM for conjugate heat transfer problems.
+
+## Installation
+
+Build instructions can be found in the repository's README.
+
+## Developer Guide
+
+See [here](developer_guide.md) for developer documentation.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,7 +57,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
         wget \
     && \
     rm -rf /var/lib/apt/lists/*
-RUN make -C ${MOOSE_DIR}/modules/heat_conduction -j
+RUN make -C ${MOOSE_DIR}/modules/heat_conduction
 # Python requirements for linting and testing
 RUN python -m pip install --upgrade pip && \
     python -m pip install \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,15 +30,15 @@ RUN DEBIAN_FRONTEND=noninteractive \
     # Install OpenFOAM build dependencies
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        libqt5opengl5-dev=5.12.8+dfsg-0ubuntu2.1 \
-        libqt5x11extras5-dev=5.12.8-0ubuntu1 \
-        libxt-dev=1:1.1.5-1 \
-        paraview=5.7.0-4ubuntu9 \
-        paraview-dev=5.7.0-4ubuntu9 \
-        qtbase5-dev=5.12.8+dfsg-0ubuntu2.1 \
-        qttools5-dev=5.12.8-0ubuntu1 \
-        qttools5-dev-tools=5.12.8-0ubuntu1 \
-        wget=1.20.3-1ubuntu2 \
+        libqt5opengl5-dev \
+        libqt5x11extras5-dev \
+        libxt-dev \
+        paraview \
+        paraview-dev \
+        qtbase5-dev \
+        qttools5-dev \
+        qttools5-dev-tools \
+        wget \
     && \
     # Install OpenFOAM
     bash ./scripts/install-openfoam.sh -o /opt/openfoam -s && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,5 +58,11 @@ RUN DEBIAN_FRONTEND=noninteractive \
     && \
     rm -rf /var/lib/apt/lists/*
 RUN make -C ${MOOSE_DIR}/modules/heat_conduction -j
+# Python requirements for linting and testing
+RUN python -m pip install --upgrade pip && \
+    python -m pip install \
+        pre-commit \
+        "fluidfoam>=0.2.4" \
+        "deepdiff>=6.1.0"
 
 ENTRYPOINT ["/bin/bash", "-c", "source /opt/openfoam/OpenFOAM-10/etc/bashrc && \"$@\"", "-s"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,5 +57,6 @@ RUN DEBIAN_FRONTEND=noninteractive \
         wget \
     && \
     rm -rf /var/lib/apt/lists/*
+RUN make -C ${MOOSE_DIR}/modules/heat_conduction -j
 
 ENTRYPOINT ["/bin/bash", "-c", "source /opt/openfoam/OpenFOAM-10/etc/bashrc && \"$@\"", "-s"]

--- a/include/base/FoamProblem.h
+++ b/include/base/FoamProblem.h
@@ -67,5 +67,4 @@ private:
   void syncToOpenFoam();
   MooseVariableFieldBase *
   getConstantMonomialVariableFromParameters(const std::string & variable_name);
-  Real variableValueAtElement(const libMesh::Elem * element, MooseVariableFieldBase * variable);
 };

--- a/src/base/FoamProblem.C
+++ b/src/base/FoamProblem.C
@@ -24,6 +24,14 @@ is_constant_monomial(const MooseVariableFieldBase & var)
 {
   return var.order() == libMesh::Order::CONSTANT && var.feType().family == FEFamily::MONOMIAL;
 }
+
+Real
+variableValueAtElement(const libMesh::Elem * element, MooseVariableFieldBase * variable)
+{
+  auto & sys = variable->sys();
+  auto dof = element->dof_number(sys.number(), variable->number(), 0);
+  return sys.solution()(dof);
+}
 }
 
 InputParameters
@@ -317,15 +325,6 @@ BuoyantFoamProblem::syncToOpenFoam()
       _app.set_patch_face_negative_heat_flux(subdomains[i], moose_hf);
     }
   }
-}
-
-Real
-BuoyantFoamProblem::variableValueAtElement(const libMesh::Elem * element,
-                                           MooseVariableFieldBase * variable)
-{
-  auto & sys = variable->sys();
-  auto dof = element->dof_number(sys.number(), variable->number(), 0);
-  return sys.solution()(dof);
 }
 
 MooseVariableFieldBase *


### PR DESCRIPTION
## Summary

<!-- Describe the changes that this pull request makes. -->
This PR updates the Dockerfile for the CI such that MOOSE's heat conduction module is built within it. This saves us building it in the CI every time.

We now deploy the docker image to, and pull from, UKAEA's Quay account (using a robot account's credentials), rather than my personal one.

The new docker image was built and pushed in [this action](https://github.com/aurora-multiphysics/hippo/actions/runs/11778147450) using revision dcc37f4.

There's a minor refactor converting a `FoamProblem` member function to a free function in an anonymous workspace.

## Related Issue

Resolves #24 
Resolves #15 

## Checklist

- [x] Tests have been written for the new/changed behaviour.
- [x] Documentation/examples have been added/updated for the new changes.
