### PR TITLE
Avoid having to have separate input files for parallel runs

### DIFF
--- a/include/base/FoamInterfaceImpl.h
+++ b/include/base/FoamInterfaceImpl.h
@@ -3,11 +3,11 @@
 #include "FoamInterface.h"
 #include "fvCFD_moose.h"
 
+#include <mpi.h>
 #include <PrimitivePatchInterpolation.H>
 
 #include <cassert>
 #include <map>
-#include <mpi.h>
 
 /*
  * Where the "generic" openFoam state lives mesh, runtime, args and decomposition info

--- a/include/base/FoamInterfaceImpl.h
+++ b/include/base/FoamInterfaceImpl.h
@@ -82,21 +82,6 @@ struct EnvImpl
     return _mesh.globalData().globalPointNumbering();
   }
 
-#if 0
-  auto
-  getPatchInterpolator(int patch_id)
-  {
-    return Foam::PrimitivePatchInterpolation(patch_id);
-  }
-
-  auto
-  getPatchInterpolator(std::string const & patch_name)
-  {
-    auto patch_id = getPatchID(patch_name)
-    return Foam::PrimitivePatchInterpolation(patch_id);
-  }
-#endif
-
   Foam::Time & getRuntime() { return _runtime; }
   Foam::argList & getArglist() { return _args.args; }
   Foam::fvMesh & getMesh() { return _mesh; }

--- a/include/mesh/FoamMesh.h
+++ b/include/mesh/FoamMesh.h
@@ -41,8 +41,8 @@ public:
 protected:
   std::vector<std::string> _foam_patch;
   std::vector<int32_t> _patch_id;
-  Hippo::FoamInterface * _interface;
   std::vector<int> _subdomain_list;
+  Hippo::FoamInterface * _interface;
   bool _serial = true;
 };
 // Local Variables:

--- a/src/base/buoyantFoamImpl.C
+++ b/src/base/buoyantFoamImpl.C
@@ -659,6 +659,7 @@ public:
 };
 
 buoyantFoamApp::~buoyantFoamApp() = default;
+
 buoyantFoamApp::buoyantFoamApp(FoamInterface * interface)
   : _interface(interface),
     _impl(std::make_unique<buoyantFoamImpl>(

--- a/src/mesh/FoamMesh.C
+++ b/src/mesh/FoamMesh.C
@@ -10,13 +10,12 @@ InputParameters
 FoamMesh::validParams()
 {
   auto params = MooseMesh::validParams();
-  // make a vector at some point
   params.addRequiredParam<std::vector<std::string>>("foam_patch",
                                                     "Name of foam boundary patches to replicate");
 
   std::vector<std::string> empty_vec;
   params.addParam<std::vector<std::string>>(
-      "foam_args", empty_vec, "List of arguments to be passed to openFoam solver");
+      "foam_args", empty_vec, "List of arguments to be passed to OpenFoam solver");
   return params;
 }
 

--- a/test/tests/buoyantFoam/buoyantFoam_par/run.i
+++ b/test/tests/buoyantFoam/buoyantFoam_par/run.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = FoamMesh
-  foam_args = '-case buoyantCavity -parallel'
+  foam_args = '-case buoyantCavity'
   foam_patch = 'topAndBottom frontAndBack'
   dim=2
 []

--- a/test/tests/cube_slice/test_1/run.i
+++ b/test/tests/cube_slice/test_1/run.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = FoamMesh
-  foam_args = '-case foaminput -parallel'
+  foam_args = '-case foaminput'
   foam_patch = ' Wall-2 Wall-3 Wall-4 Wall-5'
   dim=2
 []

--- a/test/tests/cube_slice/test_10/run.i
+++ b/test/tests/cube_slice/test_10/run.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = FoamMesh
-  foam_args = '-case foaminput -parallel'
+  foam_args = '-case foaminput'
   foam_patch = ' Wall-0 Wall-3 Wall-5'
   dim=2
 []

--- a/test/tests/cube_slice/test_2/run.i
+++ b/test/tests/cube_slice/test_2/run.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = FoamMesh
-  foam_args = '-case foaminput -parallel'
+  foam_args = '-case foaminput'
   foam_patch = ' Wall-0 Wall-3 Wall-5'
   dim=2
 []

--- a/test/tests/cube_slice/test_3/run.i
+++ b/test/tests/cube_slice/test_3/run.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = FoamMesh
-  foam_args = '-case foaminput -parallel'
+  foam_args = '-case foaminput'
   foam_patch = ' Wall-0 Wall-3 Wall-5'
   dim=2
 []

--- a/test/tests/cube_slice/test_5/run.i
+++ b/test/tests/cube_slice/test_5/run.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = FoamMesh
-  foam_args = '-case foaminput -parallel'
+  foam_args = '-case foaminput'
   foam_patch = ' Wall-0 Wall-2 Wall-4'
   dim=2
 []

--- a/test/tests/cube_slice/test_6/run.i
+++ b/test/tests/cube_slice/test_6/run.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = FoamMesh
-  foam_args = '-case foaminput -parallel'
+  foam_args = '-case foaminput'
   foam_patch = ' Wall-3'
   dim=2
 []

--- a/test/tests/cube_slice/test_7/run.i
+++ b/test/tests/cube_slice/test_7/run.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = FoamMesh
-  foam_args = '-case foaminput -parallel'
+  foam_args = '-case foaminput'
   foam_patch = ' Wall-0 Wall-1 Wall-2 Wall-3 Wall-4 Wall-5'
   dim=2
 []

--- a/test/tests/cube_slice/test_8/run.i
+++ b/test/tests/cube_slice/test_8/run.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = FoamMesh
-  foam_args = '-case foaminput -parallel'
+  foam_args = '-case foaminput'
   foam_patch = ' Wall-1 Wall-3'
   dim=2
 []

--- a/test/tests/cube_slice/test_9/run.i
+++ b/test/tests/cube_slice/test_9/run.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = FoamMesh
-  foam_args = '-case foaminput -parallel'
+  foam_args = '-case foaminput'
   foam_patch = ' Wall-0 Wall-2 Wall-4 Wall-5'
   dim=2
 []

--- a/test/tests/multiapps/flow_over_heated_plate/fluid.i
+++ b/test/tests/multiapps/flow_over_heated_plate/fluid.i
@@ -1,6 +1,6 @@
 [Mesh]
     type = FoamMesh
-    foam_args = '-case fluid-openfoam -parallel'
+    foam_args = '-case fluid-openfoam'
     foam_patch = 'interface'
     dim = 2
 []

--- a/test/tests/multiapps/temperature_set_on_openfoam_boundary/par/fluid.i
+++ b/test/tests/multiapps/temperature_set_on_openfoam_boundary/par/fluid.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = FoamMesh
-  foam_args = '-case buoyantCavity -parallel'
+  foam_args = '-case buoyantCavity'
   foam_patch = 'patch2 patch4'
   dim=2
 []


### PR DESCRIPTION
## Summary

<!-- Describe the changes that this pull request makes. -->
This change updates `FoamInterface` such that we automatically append OpenFOAM's `-parallel` flag when Hippo is run with MPI. The effect of this is that the `-parallel` flag does not have to be added to the `foam_args` option in Hippo's input files, and we do not have to have different input files for serial and parallel runs.

## Related Issue

Resolves #18 

## Checklist

- [x] Tests have been written for the new/changed behaviour.
- [x] Documentation/examples have been added/updated for the new changes.
