### PR TITLE
Attempt to reduce CI run time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/ukaea/hippo:6eb722b71542e6100fd7
+      image: quay.io/ukaea/hippo:5c52a671f8e9a3f81a74
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
       shell: bash
       run: |
         . /opt/openfoam/OpenFOAM-12/etc/bashrc || true
-        pip install -r requirements.test.txt
         ./run_tests
 
     - name: Docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v16.0.6
+    rev: v19.1.7
     hooks:
       - id: clang-format
         args: ["--style=file"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
         # Only check for syntax, do not load.
@@ -27,7 +27,7 @@ repos:
         # whitespace in the first place.
         exclude: "(.*/gold/.*)|(.*/[0-9]+/.*)"
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.4
+    rev: v1.5.5
     hooks:
       - id: remove-crlf
       - id: forbid-tabs

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ It provides tools for solving coupled conjugate heat transfer problems.
 Some simple 1 and 2D validation cases can be found in
 [the tests](https://github.com/aurora-multiphysics/hippo/tree/main/test/tests/multiapps).
 
+## Using Hippo
+
+Hippo's documentation is a work in progress,
+and can be found [here](https://aurora-multiphysics.github.io/hippo/).
+It includes an example of how to set up
+a coupled conjugate heat transfer problem.
+
 ## Install/Build
 
 Note: Only tested with GCC.

--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ you may run into errors when running Hippo.
 Hippo input files that run a MOOSE case do not require a Kernel or variables.
 However, MOOSE will still happily go off and calculate a residual.
 Since there are no variables defined,
-the residual calculation results in a division by vero and an FPE signal.
+the residual calculation results in a division by zero and an FPE signal.
 OpenFOAM will catch this signal and abort the application.
 
-There are two workarounds for this problem:
+Either of these two workarounds will work:
 
 1. Disable trapping for floating point exceptions.
    `unset FOAM_SIGFPE && unset FOAM_SETNAN`.
@@ -153,8 +153,3 @@ There are two workarounds for this problem:
      []
    []
    ```
-
-"Fork hippo" to create a new MOOSE-based application.
-
-For more information see:
-[http://mooseframework.org/create-an-app/](http://mooseframework.org/create-an-app/)

--- a/doc/content/developer_guide.md
+++ b/doc/content/developer_guide.md
@@ -18,6 +18,18 @@ Hippo's CI environment.
 This environment does not contain Hippo itself,
 as it is used for testing the build.
 
+The Docker image should be built using the
+[deploy-docker](https://github.com/aurora-multiphysics/hippo/actions/workflows/deploy-docker.yaml)
+GitHub action.
+Developers should tag the Docker image with the first 20 characters of
+the Git revision they are building the image with.
+Once the image has been built and [pushed to Quay.io](#quayio),
+a developer should open a PR that updates `.github/ci.yml`
+to use the new tag.
+Once that PR has passed the CI it can be merged.
+The newest version of the Docker image can then be tagged
+with `latest` on Quay.io.
+
 ### Quay.io
 
 The built docker image is stored under

--- a/doc/content/index.md
+++ b/doc/content/index.md
@@ -6,7 +6,20 @@ A MOOSE multiapp wrapping OpenFOAM for conjugate heat transfer problems.
 
 ## Installation
 
-Build instructions can be found in the repository's README.
+Build instructions can be found in the repository's
+[README](https://github.com/aurora-multiphysics/hippo/blob/main/README.md).
+
+Alternatively, you can use Hippo in a Docker container.
+An image with all of Hippo's dependencies pre-installed
+can be found on [quay.io](https://quay.io/repository/ukaea/hippo).
+You will need to mount and install Hippo within the container.
+
+```shell
+$ git clone https://github.com/aurora-multiphysics/hippo.git
+$ docker run -it -v $(pwd)/hippo:/opt/hippo quay.io/ukaea/hippo:latest bash
+$ make -j
+$ hippo-opt --help
+```
 
 ## Setting Up a Case
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -102,4 +102,7 @@ RUN bash ./scripts/install-openfoam.sh -o /opt/openfoam -s
 RUN conda install --yes --file requirements.test.txt \
     && conda install --yes pre-commit
 
+# Pull down MOOSE's 'large_media' submodule for building docs
+RUN git -C "${MOOSE_DIR}" submodule update --init large_media
+
 ENTRYPOINT ["/bin/bash", "-c", "source /opt/openfoam/OpenFOAM-12/etc/bashrc && \"$@\"", "-s"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -99,8 +99,8 @@ COPY ./scripts/openfoam-prefs.sh /root/.OpenFOAM/prefs.sh
 RUN bash ./scripts/install-openfoam.sh -o /opt/openfoam -s
 
 # Python linting and testing requirements
-RUN conda install --yes --file requirements.test.txt \
-    && conda install --yes pre-commit
+COPY ./requirements.test.txt ./requirements.test.txt
+RUN conda install pre-commit --file requirements.test.txt -S --yes
 
 # Pull down MOOSE's 'large_media' submodule for building docs
 RUN git -C "${MOOSE_DIR}" submodule update --init large_media

--- a/include/base/FoamProblem.h
+++ b/include/base/FoamProblem.h
@@ -18,7 +18,7 @@ public:
   virtual void externalSolve() override;
   virtual void syncSolutions(Direction /* dir */) override;
   virtual bool converged(const unsigned int nl_sys_num) override { return true; }
-  virtual void addExternalVariables() override{};
+  virtual void addExternalVariables() override {};
   // Want to be able to share the object from here so we don't
   // have to pass the args around and problem is available in
   // other objects

--- a/include/mesh/Foam2MooseMeshGen.h
+++ b/include/mesh/Foam2MooseMeshGen.h
@@ -25,7 +25,7 @@ class FoamPoint
   int32_t _gid = -1;
 
 public:
-  FoamPoint(double x0, double x1, double x2, int32_t id) : _pos{x0, x1, x2}, _gid(id){};
+  FoamPoint(double x0, double x1, double x2, int32_t id) : _pos{x0, x1, x2}, _gid(id) {};
   FoamPoint() {}
 
   libMesh::Point get_point() const { return libMesh::Point(_pos[0], _pos[1], _pos[2]); }

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,2 +1,2 @@
 fluidfoam>=0.2.8
-scipy>=1.15.1
+scipy

--- a/src/main.C
+++ b/src/main.C
@@ -9,29 +9,13 @@
 
 #include "hippoTestApp.h"
 
-#include <MooseInit.h>
-#include <Moose.h>
-#include <MooseApp.h>
-#include <AppFactory.h>
+#include <MooseMain.h>
 
 // Create a performance log
 PerfLog Moose::perf_log("hippo");
 
-// Begin the main program.
 int
 main(int argc, char * argv[])
 {
-  // Initialize MPI, solvers and MOOSE
-  MooseInit init(argc, argv);
-
-  // Register this application's MooseApp and any it depends on
-  hippoTestApp::registerApps();
-
-  // Create an instance of the application and store it in a smart pointer for easy cleanup
-  std::shared_ptr<MooseApp> app = AppFactory::createAppShared("hippoTestApp", argc, argv);
-
-  // Execute the application
-  app->run();
-
-  return 0;
+  return Moose::main<hippoTestApp>(argc, argv);
 }

--- a/test/tests/multiapps/unsteady_heat_conduction_in_infinite_system/fluid-openfoam/system/blockMeshDict
+++ b/test/tests/multiapps/unsteady_heat_conduction_in_infinite_system/fluid-openfoam/system/blockMeshDict
@@ -21,7 +21,7 @@ vertices
 
 blocks
 (
-    hex (0 1 2 3 4 5 6 7) (100 1 1) simpleGrading (25 1 1)
+    hex (0 1 2 3 4 5 6 7) (50 1 1) simpleGrading (25 1 1)
 );
 
 boundary

--- a/test/tests/multiapps/unsteady_heat_conduction_in_infinite_system/fluid-openfoam/system/decomposeParDict
+++ b/test/tests/multiapps/unsteady_heat_conduction_in_infinite_system/fluid-openfoam/system/decomposeParDict
@@ -14,13 +14,13 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-numberOfSubdomains 6;
+numberOfSubdomains 2;
 
 method          simple;
 
 simpleCoeffs
 {
-    n               (6 1 1);
+    n               (2 1 1);
 }
 
 hierarchicalCoeffs

--- a/test/tests/multiapps/unsteady_heat_conduction_in_infinite_system/run.i
+++ b/test/tests/multiapps/unsteady_heat_conduction_in_infinite_system/run.i
@@ -3,7 +3,7 @@
         type = GeneratedMeshGenerator
         dim = 3
 
-        nx = 100
+        nx = 50
         xmin = -1.0
         xmax = 0.0
 
@@ -18,7 +18,7 @@
         # Calculated here:
         # https://openfoamwiki.net/index.php/Scripts/blockMesh_grading_calculation
         # Based on a grading factor of 25 and 100 elements.
-        bias_x = 0.9680089966756151
+        bias_x = 0.9364198516989446
     []
 []
 

--- a/test/tests/multiapps/unsteady_heat_conduction_in_infinite_system/tests
+++ b/test/tests/multiapps/unsteady_heat_conduction_in_infinite_system/tests
@@ -7,8 +7,8 @@
     [run]
       type = RunApp
       input = run.i
-      min_parallel = 6
-      max_parallel = 6
+      min_parallel = 2
+      max_parallel = 2
       prereq = unsteady_heat_conduction_in_infinite_system/setup
     []
     [reconstruct]


### PR DESCRIPTION
## Summary

<!-- Describe the changes that this pull request makes. -->
This PR does a few things:

- Attempts to reduce the run time of the CI by reducing the size of the "unsteady heat conduction" test and reducing the number of parallel workers (so it does not exceed the number of CPUs available to the GitHub runners).
- Fixes some typos in the README.
- Adds a link to the built docs to the README.
- Fixes the run time deprecation warnings we were getting from MOOSE.
- Remove an unecessary `pip install` from the CI.

## Checklist

- [x] Tests have been written for the new/changed behaviour.
- [x] Documentation/examples have been added/updated for the new changes.
