### PR TITLE
Fix bug when sub-cycling a Hippo app

### DIFF
--- a/include/base/FoamSolver.h
+++ b/include/base/FoamSolver.h
@@ -32,11 +32,15 @@ public:
   void setCurrentTime(double time) { runTime().setTime(time, runTime().timeIndex()); }
   // Set the time at which the solver should terminate.
   void setEndTime(double time) { runTime().setEndTime(time); }
+  // Get the current time step size in seconds.
+  double timeDelta() const { return runTime().deltaT().value(); }
+
+protected:
+  Foam::Time & runTime() { return const_cast<Foam::Time &>(_solver->runTime); }
+  const Foam::Time & runTime() const { return _solver->runTime; }
 
 private:
   Foam::solver * _solver = nullptr;
-
-  Foam::Time & runTime() { return const_cast<Foam::Time &>(_solver->runTime); }
 };
 
 } // namespace Hippo

--- a/include/mesh/FoamMesh.h
+++ b/include/mesh/FoamMesh.h
@@ -33,6 +33,7 @@ public:
   bool isSerial() const { return _serial; }
   libMesh::Elem * getElemPtr(int local) const;
   Foam::fvMesh & fvMesh() { return _foam_mesh; }
+  Hippo::FoamRuntime & runTime() { return _foam_runtime; }
 
   std::vector<int32_t> n_faces{0};
   // The index offset into the MOOSE element array, for the current rank.
@@ -41,7 +42,7 @@ public:
   // to get the i-th element owned by the current rank from the mesh.
   size_t rank_element_offset{0};
 
-protected:
+private:
   std::vector<std::string> _foam_patch;
   Hippo::FoamRuntime _foam_runtime;
   Foam::fvMesh _foam_mesh;

--- a/include/solvers/timesteppers/FoamTimeStepper.h
+++ b/include/solvers/timesteppers/FoamTimeStepper.h
@@ -22,6 +22,7 @@ public:
 
   /// Initial time-step size comes from the MOOSE input file.
   virtual Real computeInitialDT();
+
   /**
    * Read the time-step MOOSE wants to take and set it on the OpenFOAM problem.
    *
@@ -30,11 +31,12 @@ public:
    * solve needs to be updated to reflect this.
    */
   virtual Real computeDT();
+
   /// Set the initial time, final time and time step size on the OpenFOAM
   /// problem.
   virtual void init();
 
-private:
+protected:
   Hippo::FoamSolver & solver() { return problem()->solver(); }
   FoamProblem * problem();
 };

--- a/src/timesteppers/FoamTimeStepper.C
+++ b/src/timesteppers/FoamTimeStepper.C
@@ -4,7 +4,18 @@
 #include <TimeStepper.h>
 #include <Transient.h>
 
+#include <cmath>
+
 registerMooseObject("hippoApp", FoamTimeStepper);
+
+namespace
+{
+bool
+isClose(double a, double b, double tolerance = 1e-12)
+{
+  return std::fabs(a - b) <= tolerance;
+}
+}
 
 InputParameters
 FoamTimeStepper::validParams()
@@ -33,6 +44,23 @@ FoamTimeStepper::computeInitialDT()
 Real
 FoamTimeStepper::computeDT()
 {
+  // The problem here is that floating point errors were sometimes causing
+  // MOOSE to ask for tiny time steps from OpenFOAM when sub-cycling. This
+  // would result in an infinite loop where the MOOSE would never consider the
+  // applications synchronised.
+  // Setting `_executioner.setTimestepTolerance` did not seem to help.
+  // This is potentially not ideal, but if we look for small changes to the
+  // time step size compared to the previous step, then we can prevent that
+  // small change by reverting to the previous time step size. We use the
+  // OpenFOAM solver as a proxy for the previous time step size (as we set that
+  // time step size every time we call this function).
+  // This solution allows MOOSE to set large time step deviations (to do a real
+  // synchronization), but should prevent small numerical errors accumulating.
+  if (auto foam_dt = solver().timeDelta(); isClose(_dt, foam_dt))
+  {
+    solver().setTimeDelta(foam_dt);
+    return foam_dt;
+  }
   solver().setTimeDelta(_dt);
   return _dt;
 }


### PR DESCRIPTION
## Summary

<!-- Describe the changes that this pull request makes. -->
The application would sometime enter an infinite loop when sub-cycling as MOOSE would never recognise that multiapps were synchronised. It was caused by accumulating numerical errors in the timestep size.

This change attempts to prevent small numerical errors accumulating by preventing time step changes if the change is very small.

## Checklist

- [ ] Tests have been written for the new/changed behaviour.
- [ ] Documentation/examples have been added/updated for the new changes.
