### PR TITLE
Fix openfoam build script

### DIFF
--- a/scripts/openfoam.patch
+++ b/scripts/openfoam.patch
@@ -294,6 +294,7 @@ index 03433b398..dc9e39c0b 100644
 +    int rank,size;
 +    MPI_Comm_rank(comm,&rank);
 +    MPI_Comm_size(comm,&size);
++    std::cout << rank << ", " << size <<std::endl;
 +    int flag;
 +    MPI_Initialized(&flag);
 +    if (!flag) {

--- a/scripts/openfoam.patch
+++ b/scripts/openfoam.patch
@@ -294,7 +294,7 @@ index 03433b398..dc9e39c0b 100644
 +    int rank,size;
 +    MPI_Comm_rank(comm,&rank);
 +    MPI_Comm_size(comm,&size);
-+    std::cout << rank << ", " << size <<std::endl;
++
 +    int flag;
 +    MPI_Initialized(&flag);
 +    if (!flag) {


### PR DESCRIPTION
## Summary

<!-- Describe the changes that this pull request makes. -->
Fix the OpenFOAM build script. 

In `b2b12c7` I had removed a print statement from the OpenFOAM patch, however I had not updated the line ranges in the diff-block. This meant that the patch was not valid, and applying the patch would cause an error: `error: corrupt patch at line 386`.

To fix, we revert `b2b12c7` and instead of removing the print statement, we make it a blank line. I think this works within the flow of the function and means I don't have to manually update the diff-block's line range.

## Checklist

- [x] Tests have been written for the new/changed behaviour.
- [x] Documentation/examples have been added/updated for the new changes.
