### PR TITLE
Update requirements.test.txt so that the python unit tests can use vtk to read OpenFOAM data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/ukaea/hippo:ce40b973303ad714419c
+      image: quay.io/ukaea/hippo:4a33e58cc914ad502556
       options: --user root
 
     steps:

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,2 +1,3 @@
 fluidfoam>=0.2.8
+pyvista>=0.43
 scipy


### PR DESCRIPTION
## Summary

There seems to be a bug in the `fluidfoam` python module when reading polyhedral elements with many faces. As a result, for the polyhedral tests it is useful to use `pyvista` which has no such issue. This needs to be added to the `requirements.test.txt` and the docker container then needs to be updated.

## Related Issue

This is a prerequisite to solving the non-conformal interface issue but does not close it. 

## Checklist

- [x] Update requirements.test.txt
- [x] Deploy docker container
- [x] Update docker container has in CI
