### PR TITLE
Allow CI to run as non-root user

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/ukaea/hippo:4a33e58cc914ad502556
+      image: quay.io/ukaea/hippo:94c602bb87e287be87da
       options: --user 1001
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/ukaea/hippo:94c602bb87e287be87da
+      image: quay.io/ukaea/hippo:e61505f86052be9bb6a5
       options: --user 1001
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: quay.io/ukaea/hippo:e61505f86052be9bb6a5
-      options: --user 1001
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         # used by 'actions/checkout', so git operations fail.
         # https://github.com/actions/checkout/issues/766
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        git config --global --add safe.directory /opt/moose
         pre-commit install
         SKIP=no-commit-to-branch pre-commit run --all
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: quay.io/ukaea/hippo:4a33e58cc914ad502556
-      options: --user root
+      options: --user 1001
 
     steps:
     - uses: actions/checkout@v4
@@ -41,9 +41,6 @@ jobs:
 
     - name: Test
       shell: bash
-      env:
-        OMPI_ALLOW_RUN_AS_ROOT: 1
-        OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
       run: |
         . /opt/openfoam/OpenFOAM-12/etc/bashrc || true
         unset FOAM_SIGFPE && unset FOAM_SETNAN

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -119,6 +119,7 @@ RUN git -C "${MOOSE_DIR}" submodule update --init large_media
 
 RUN groupadd -g $GID --non-unique $UNAME
 RUN useradd -u $UID -g $GID --shell /bin/bash --create-home $UNAME
+RUN chown -R $UNAME:$UNAME /opt/moose
 USER $UNAME
 ENV USER $UNAME
 WORKDIR /home/$UNAME

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,8 +27,8 @@ FROM rockylinux/rockylinux:8.10 AS main
 # docker build --build-arg "MOOSE_JOBS=4" --build-arg "OPENFOAM_JOBS=8" ...
 # Args must be in the same image in multi-stage build
 # Allow specifying UID and GID to avoid permissions problems when mounting directories
-ARG UID=1000
-ARG GID=1000
+ARG UID=1001
+ARG GID=1001
 ARG UNAME=hippo-user
 # Number of parallel jobs for MOOSE build
 ARG MOOSE_JOBS=1


### PR DESCRIPTION
## Summary

Currently, due to `checkout` actions shenanigans, CI is run as root. But OpenFOAM's dynamically generated code cannot be run as root, so ideally a workaround should be found. We wish to change this by updating the Docker container hippo-user UID to 1001.

## Related Issue

This is necessary to merge #55 

## Checklist

- [x] Update docker container
- [x] Update CI