### PR TITLE
Include cstdint in CommUtil.h for int32_t and friends

### DIFF
--- a/include/util/CommUtil.h
+++ b/include/util/CommUtil.h
@@ -4,6 +4,7 @@
 
 #include <mpi.h>
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 /*


### PR DESCRIPTION
## Summary

Includes missing `<cstdint>` in `CommUtil.h`
