### PR TITLE
Add split mesh tests

### DIFF
--- a/test/tests/mesh/polygonal/tests
+++ b/test/tests/mesh/polygonal/tests
@@ -31,5 +31,29 @@
       input = test.py
       prereq = poly/reconstruct
     []
+    [split_mesh]
+        type = RunApp
+        input = run.i
+        cli_args = '--split-mesh 2 --split-file mesh_split'
+        prereq = poly/verify_distributed
+    []
+    [run_use_split]
+      type = RunApp
+      input = run.i
+      prereq = poly/split_mesh
+      min_parallel=2
+      max_parallel=2
+      cli_args='--use-split --split-file mesh_split'
+    []
+    [reconstruct_split]
+      type = RunCommand
+      command = 'bash -c "reconstructPar -case fluid-openfoam"'
+      prereq = poly/run_use_split
+    []
+    [verify_split]
+      type = PythonUnitTest
+      input = test.py
+      prereq = poly/reconstruct_split
+    []
   []
 []

--- a/test/tests/mesh/quadrilateral/tests
+++ b/test/tests/mesh/quadrilateral/tests
@@ -31,5 +31,29 @@
       input = test.py
       prereq = quad/reconstruct
     []
+    [split_mesh]
+        type = RunApp
+        input = run.i
+        cli_args = '--split-mesh 2 --split-file mesh_split'
+        prereq = quad/verify_distributed
+    []
+    [run_use_split]
+      type = RunApp
+      input = run.i
+      prereq = quad/split_mesh
+      min_parallel=2
+      max_parallel=2
+      cli_args='--use-split --split-file mesh_split'
+    []
+    [reconstruct_split]
+      type = RunCommand
+      command = 'bash -c "reconstructPar -case fluid-openfoam"'
+      prereq = quad/run_use_split
+    []
+    [verify_split]
+      type = PythonUnitTest
+      input = test.py
+      prereq = quad/reconstruct_split
+    []
   []
 []

--- a/test/tests/mesh/triangular/tests
+++ b/test/tests/mesh/triangular/tests
@@ -31,5 +31,29 @@
       input = test.py
       prereq = tri/reconstruct
     []
+    [split_mesh]
+        type = RunApp
+        input = run.i
+        cli_args = '--split-mesh 2 --split-file mesh_split'
+        prereq = tri/verify_distributed
+    []
+    [run_use_split]
+      type = RunApp
+      input = run.i
+      prereq = tri/split_mesh
+      min_parallel=2
+      max_parallel=2
+      cli_args='--use-split --split-file mesh_split'
+    []
+    [reconstruct_split]
+      type = RunCommand
+      command = 'bash -c "reconstructPar -case fluid-openfoam"'
+      prereq = tri/run_use_split
+    []
+    [verify_split]
+      type = PythonUnitTest
+      input = test.py
+      prereq = tri/reconstruct_split
+    []
   []
 []


### PR DESCRIPTION
## Summary

Adds some additional tests to explicitly ensure that split meshes work with Hippo. While this is to be expected, its good to confirm this.

## Related Issue

Resolves #112 

## Checklist

- [x] Tests have been written for the new/changed behaviour.
