### PR TITLE
Build OpenFOAM solvers in Apptainer development container

### DIFF
--- a/apptainer/hippo-dev.def
+++ b/apptainer/hippo-dev.def
@@ -91,6 +91,11 @@ From: ghcr.io/idaholab/apptainer/moose-dev-openmpi-x86_64:2026.03.19
     # So that prefs can be found when not run as root
     cp /root/.OpenFOAM/prefs.sh /opt/openfoam/OpenFOAM-12/etc
 
+    echo 'export MPI_ROOT=/opt/openmpi' >> /opt/openfoam/OpenFOAM-12/etc/prefs.sh
+    echo 'export MPI_ARCH_FLAGS="-DOMPI_SKIP_MPICXX"' >> /opt/openfoam/OpenFOAM-12/etc/prefs.sh
+    echo 'export MPI_ARCH_INC="-isystem $MPI_ROOT/include"' >> /opt/openfoam/OpenFOAM-12/etc/prefs.sh
+    echo 'export MPI_ARCH_LIBS="-L$MPI_ROOT/lib -lmpi"' >> /opt/openfoam/OpenFOAM-12/etc/prefs.sh
+
     # Ensure base OpenFOAM directory is correct when bashrc is sourced in future
     sed -i 's|export FOAM_INST_DIR=\$HOME/\$WM_PROJECT|export FOAM_INST_DIR=/opt/openfoam|' /opt/openfoam/OpenFOAM-12/etc/bashrc
 

--- a/apptainer/hippo-dev.def
+++ b/apptainer/hippo-dev.def
@@ -105,4 +105,3 @@ From: ghcr.io/idaholab/apptainer/moose-dev-openmpi-x86_64:2026.03.19
     . /opt/openfoam/OpenFOAM-12/etc/bashrc
     unset FOAM_SIGFPE
     export MOOSE_DIR=/opt/moose
-    export MPI_ROOT=/opt/openmpi

--- a/apptainer/hippo-release.def
+++ b/apptainer/hippo-release.def
@@ -43,7 +43,6 @@ From: quay.io/ukaea/hippo:dev-b32c37aa8f
     fi
 
 %environment
-    export MPI_ROOT=/opt/openmpi
     export MOOSE_DIR=/opt/moose
     if [ -f $HOME/.OpenFOAM/prefs.sh ]; then
         echo "WARNING: Potential clash of OpenFOAM environment variables from $HOME/.OpenFOAM/prefs.sh. Consider removing!"

--- a/apptainer/hippo-release.def
+++ b/apptainer/hippo-release.def
@@ -1,5 +1,5 @@
 Bootstrap: oras
-From: quay.io/ukaea/hippo:dev-febd5a9693
+From: quay.io/ukaea/hippo:dev-b32c37aa8f
 
 %files
     .git /opt/hippo/.git

--- a/apptainer/hippo-release.def
+++ b/apptainer/hippo-release.def
@@ -1,5 +1,5 @@
 Bootstrap: oras
-From: quay.io/ukaea/hippo:dev-b32c37aa8f
+From: quay.io/ukaea/hippo:dev-29d0b00e83
 
 %files
     .git /opt/hippo/.git

--- a/scripts/install-openfoam.sh
+++ b/scripts/install-openfoam.sh
@@ -112,7 +112,8 @@ wmRefresh || true
     && ${ALLWMAKE} dep \
     && ${ALLWMAKE} src/ \
     && ${ALLWMAKE} applications/modules/ \
-    && ${ALLWMAKE} applications/utilities/
+    && ${ALLWMAKE} applications/utilities/ \
+    && ${ALLWMAKE} applications/solvers/
 )
 
 if [ ${STRIP_SOURCES} -eq 1 ]; then


### PR DESCRIPTION
## Summary

Some tests now require `foamRun` to be called, but these are not built by the `install-openfoam.sh` script. Also changes the `FOAM_INST_DIR`  location in the bashrc to ensure consistency between container building and usage.

## Checklist

- [x] Tests have been written for the new/changed behaviour.
- [x] Documentation/examples have been added/updated for the new changes.
