### PR TITLE
Add thermal hydraulics module to the dev container

### DIFF
--- a/apptainer/hippo-dev.def
+++ b/apptainer/hippo-dev.def
@@ -81,6 +81,8 @@ From: ghcr.io/idaholab/apptainer/moose-dev-openmpi-x86_64:2026.03.19
 
     make -C "${MOOSE_DIR}/modules/heat_transfer" -j {{ MOOSE_JOBS }} METHOD=opt
     make -C "${MOOSE_DIR}/modules/heat_transfer" -j {{ MOOSE_JOBS }} METHOD=dbg
+    make -C "${MOOSE_DIR}/modules/thermal_hydraulics" -j {{ MOOSE_JOBS }} METHOD=opt
+    make -C "${MOOSE_DIR}/modules/thermal_hydraulics" -j {{ MOOSE_JOBS }} METHOD=dbg
 
 
     ln -s "${MPI_ROOT}/lib" "${MPI_ROOT}/lib64"

--- a/apptainer/hippo-release.def
+++ b/apptainer/hippo-release.def
@@ -1,5 +1,5 @@
 Bootstrap: oras
-From: quay.io/ukaea/hippo:dev-29d0b00e83
+From: quay.io/ukaea/hippo:dev-4f60782085
 
 %files
     .git /opt/hippo/.git


### PR DESCRIPTION
## Summary

Build thermal hydraulics module in the dev container. This is commonly used module with Hippo.