### PR TITLE
Override the fvpatch field type basedon the FoamBC class

### DIFF
--- a/include/bcs/FoamBCBase.h
+++ b/include/bcs/FoamBCBase.h
@@ -7,6 +7,8 @@
 #include <MooseObject.h>
 #include <MooseTypes.h>
 #include <MooseVariableFieldBase.h>
+#include <volFieldsFwd.H>
+#include "MooseError.h"
 #include "VariadicTable.h"
 
 typedef std::tuple<std::string, std::string, std::string, std::string, std::string> BCInfoTableRow;
@@ -43,6 +45,9 @@ protected:
 
   // Get the data vector of the MOOSE field on a subdomain
   std::vector<Real> getMooseVariableArray(int subdomain_id);
+
+  void constructFoamScalarPatch(const std::string & patch_name, const std::string & bc_type);
+  void constructFoamVectorPatch(const std::string & patch_name, const std::string & bc_type);
 
   // Pointer to Moose variable used to impose BC
   MooseVariableFieldBase * _moose_var;

--- a/include/bcs/FoamBCBase.h
+++ b/include/bcs/FoamBCBase.h
@@ -53,7 +53,7 @@ protected:
   // Construct boundary patch for scalar fields
   void constructFoamScalarPatch(const std::string & patch_name, const std::string & bc_type);
 
-  // update the energy equation, if the temperature field is updated the energy equation must be
+  // Update the energy equation, if the temperature field is updated the energy equation must be
   void
   updateEnergyPatch(const Foam::volScalarField & var, Foam::label id, const std::string & bc_type);
 

--- a/include/bcs/FoamBCBase.h
+++ b/include/bcs/FoamBCBase.h
@@ -14,12 +14,15 @@
 typedef std::tuple<std::string, std::string, std::string, std::string, std::string, std::string>
     BCInfoTableRow;
 
+// valid underlying Foam BC types
+static MooseEnum _foam_bc_types("fixedGradient fixedValue");
+
 class FoamBCBase : public MooseObject, public Coupleable
 {
 public:
   static InputParameters validParams();
 
-  explicit FoamBCBase(const InputParameters & params);
+  explicit FoamBCBase(const InputParameters & params, const std::string & bc_type);
 
   virtual void imposeBoundaryCondition() = 0;
 

--- a/include/bcs/FoamBCBase.h
+++ b/include/bcs/FoamBCBase.h
@@ -48,8 +48,10 @@ protected:
 
   // Construct boundary patch for scalar fields
   void constructFoamScalarPatch(const std::string & patch_name, const std::string & bc_type);
+
   // update the energy equation, if the temperature field is updated the energy equation must be
   void updateEnergyPatch(const std::string & patch_name, const std::string & bc_type);
+
   // Construct boundary patch for vector fields
   void constructFoamVectorPatch(const std::string & patch_name, const std::string & bc_type);
 

--- a/include/bcs/FoamBCBase.h
+++ b/include/bcs/FoamBCBase.h
@@ -9,20 +9,23 @@
 #include <MooseVariableFieldBase.h>
 #include <volFieldsFwd.H>
 #include "MooseError.h"
-#include "VariadicTable.h"
 
 typedef std::tuple<std::string, std::string, std::string, std::string, std::string, std::string>
     BCInfoTableRow;
 
 // valid underlying Foam BC types
-static MooseEnum _foam_bc_types("fixedGradient fixedValue");
+enum class FoamBCType
+{
+  fixedValue,
+  fixedGradient
+};
 
 class FoamBCBase : public MooseObject, public Coupleable
 {
 public:
   static InputParameters validParams();
 
-  explicit FoamBCBase(const InputParameters & params, const std::string & bc_type);
+  explicit FoamBCBase(const InputParameters & params, const FoamBCType bc_type);
 
   virtual void imposeBoundaryCondition() = 0;
 
@@ -51,14 +54,14 @@ protected:
   std::vector<Real> getMooseVariableArray(int subdomain_id);
 
   // Construct boundary patch for scalar fields
-  void constructFoamScalarPatch(const std::string & patch_name, const std::string & bc_type);
+  void constructFoamScalarPatch(const std::string & patch_name, const FoamBCType bc_type);
 
   // Update the energy equation, if the temperature field is updated the energy equation must be
   void
-  updateEnergyPatch(const Foam::volScalarField & var, Foam::label id, const std::string & bc_type);
+  updateEnergyPatch(const Foam::volScalarField & var, Foam::label id, const FoamBCType bc_type);
 
   // Construct boundary patch for vector fields
-  void constructFoamVectorPatch(const std::string & patch_name, const std::string & bc_type);
+  void constructFoamVectorPatch(const std::string & patch_name, const FoamBCType bc_type);
 
   // Pointer to Moose variable used to impose BC
   MooseVariableFieldBase * _moose_var;

--- a/include/bcs/FoamBCBase.h
+++ b/include/bcs/FoamBCBase.h
@@ -11,7 +11,8 @@
 #include "MooseError.h"
 #include "VariadicTable.h"
 
-typedef std::tuple<std::string, std::string, std::string, std::string, std::string> BCInfoTableRow;
+typedef std::tuple<std::string, std::string, std::string, std::string, std::string, std::string>
+    BCInfoTableRow;
 
 class FoamBCBase : public MooseObject, public Coupleable
 {
@@ -50,7 +51,8 @@ protected:
   void constructFoamScalarPatch(const std::string & patch_name, const std::string & bc_type);
 
   // update the energy equation, if the temperature field is updated the energy equation must be
-  void updateEnergyPatch(const std::string & patch_name, const std::string & bc_type);
+  void
+  updateEnergyPatch(const Foam::volScalarField & var, Foam::label id, const std::string & bc_type);
 
   // Construct boundary patch for vector fields
   void constructFoamVectorPatch(const std::string & patch_name, const std::string & bc_type);
@@ -64,4 +66,7 @@ protected:
   // Boundaries that this object applies to
   // TODO: Replace with inherited from BoundaryRestricted once FoamMesh is updated
   std::vector<SubdomainName> _boundary;
+
+  // Records whether the boundary condition type has been replaced
+  bool _patch_replaced;
 };

--- a/include/bcs/FoamBCBase.h
+++ b/include/bcs/FoamBCBase.h
@@ -46,7 +46,11 @@ protected:
   // Get the data vector of the MOOSE field on a subdomain
   std::vector<Real> getMooseVariableArray(int subdomain_id);
 
+  // Construct boundary patch for scalar fields
   void constructFoamScalarPatch(const std::string & patch_name, const std::string & bc_type);
+  // update the energy equation, if the temperature field is updated the energy equation must be
+  void updateEnergyPatch(const std::string & patch_name, const std::string & bc_type);
+  // Construct boundary patch for vector fields
   void constructFoamVectorPatch(const std::string & patch_name, const std::string & bc_type);
 
   // Pointer to Moose variable used to impose BC

--- a/include/bcs/FoamPostprocessorBCBase.h
+++ b/include/bcs/FoamPostprocessorBCBase.h
@@ -10,7 +10,7 @@ class FoamPostprocessorBCBase : public FoamBCBase, public PostprocessorInterface
 public:
   static InputParameters validParams();
 
-  explicit FoamPostprocessorBCBase(const InputParameters & params, const std::string & bc_type);
+  explicit FoamPostprocessorBCBase(const InputParameters & params, const FoamBCType bc_type);
 
   // returns the moose Postprocessor imposed on OpenFOAM
   VariableName moosePostprocessor() const { return _pp_name; }

--- a/include/bcs/FoamPostprocessorBCBase.h
+++ b/include/bcs/FoamPostprocessorBCBase.h
@@ -10,7 +10,7 @@ class FoamPostprocessorBCBase : public FoamBCBase, public PostprocessorInterface
 public:
   static InputParameters validParams();
 
-  explicit FoamPostprocessorBCBase(const InputParameters & params);
+  explicit FoamPostprocessorBCBase(const InputParameters & params, const std::string & bc_type);
 
   // returns the moose Postprocessor imposed on OpenFOAM
   VariableName moosePostprocessor() const { return _pp_name; }

--- a/include/bcs/FoamVariableBCBase.h
+++ b/include/bcs/FoamVariableBCBase.h
@@ -9,7 +9,7 @@ class FoamVariableBCBase : public FoamBCBase
 public:
   static InputParameters validParams();
 
-  explicit FoamVariableBCBase(const InputParameters & params, const std::string & bc_type);
+  explicit FoamVariableBCBase(const InputParameters & params, const FoamBCType bc_type);
 
   // returns the moose AuxVariable imposed on OpenFOAM
   VariableName mooseVariable() const { return _moose_var->get().name(); }

--- a/include/bcs/FoamVariableBCBase.h
+++ b/include/bcs/FoamVariableBCBase.h
@@ -9,7 +9,7 @@ class FoamVariableBCBase : public FoamBCBase
 public:
   static InputParameters validParams();
 
-  explicit FoamVariableBCBase(const InputParameters & params);
+  explicit FoamVariableBCBase(const InputParameters & params, const std::string & bc_type);
 
   // returns the moose AuxVariable imposed on OpenFOAM
   VariableName mooseVariable() const { return _moose_var->get().name(); }

--- a/src/bcs/FoamBCBase.C
+++ b/src/bcs/FoamBCBase.C
@@ -25,15 +25,13 @@ FoamBCBase::validParams()
   params.addRequiredParam<std::string>("foam_variable",
                                        "Name of a Foam field. e.g. T (temperature) U (velocity).");
 
-  params.addPrivateParam<std::string>("_foam_bc_type");
-
   params.registerSystemAttributeName("FoamBC");
   params.registerBase("FoamBC");
 
   return params;
 }
 
-FoamBCBase::FoamBCBase(const InputParameters & params)
+FoamBCBase::FoamBCBase(const InputParameters & params, const std::string & bc_type)
   : MooseObject(params),
     Coupleable(this, false),
     _foam_variable(params.get<std::string>("foam_variable")),
@@ -63,12 +61,16 @@ FoamBCBase::FoamBCBase(const InputParameters & params)
   if (_boundary.empty())
     _boundary = all_subdomain_names;
 
+  // Check validity of BC Type
+  if (_foam_bc_types.find(bc_type) == _foam_bc_types.items().end())
+    mooseError("'", bc_type, "' invalid Foam BC Type.");
+
   for (auto subdomain : _boundary)
   {
     if (_mesh->foamHasObject<Foam::volScalarField>(_foam_variable))
-      constructFoamScalarPatch(subdomain, params.get<std::string>("_foam_bc_type"));
+      constructFoamScalarPatch(subdomain, bc_type);
     else if (_mesh->foamHasObject<Foam::volVectorField>(_foam_variable))
-      constructFoamVectorPatch(subdomain, params.get<std::string>("_foam_bc_type"));
+      constructFoamVectorPatch(subdomain, bc_type);
     else
       mooseError("Variable must have type scalar or vector.");
   }
@@ -81,7 +83,7 @@ FoamBCBase::constructFoamScalarPatch(const std::string & patch_name, const std::
   auto & var = foam_mesh.lookupObjectRef<Foam::volScalarField>(_foam_variable);
   Foam::label id = foam_mesh.boundary().findIndex(patch_name);
 
-  if (var.boundaryField()[id].type() == bc_type)
+  if (bc_type == var.boundaryField()[id].type())
     return;
 
   // Used by getInfoRow to report in the BC table that the patch as been replaced
@@ -97,10 +99,6 @@ FoamBCBase::constructFoamScalarPatch(const std::string & patch_name, const std::
   {
     bcDict.add("type", "fixedValue");
     bcDict.add("value", "uniform 0.");
-  }
-  else
-  {
-    mooseError("Invalid _foam_bc_type");
   }
 
   var.boundaryFieldRef().set(
@@ -119,7 +117,7 @@ FoamBCBase::constructFoamVectorPatch(const std::string & patch_name, const std::
   auto & var = foam_mesh.lookupObjectRef<Foam::volVectorField>(_foam_variable);
   Foam::label id = foam_mesh.boundary().findIndex(patch_name);
 
-  if (var.boundaryField()[id].type() == bc_type)
+  if (bc_type == var.boundaryField()[id].type())
     return;
 
   _patch_replaced = true;
@@ -135,10 +133,7 @@ FoamBCBase::constructFoamVectorPatch(const std::string & patch_name, const std::
     bcDict.add("type", "fixedValue");
     bcDict.add("value", "uniform (0. 0. 0.)");
   }
-  else
-  {
-    mooseError("Invalid _foam_bc_type");
-  }
+
   var.boundaryFieldRef().set(
       id,
       Foam::fvPatchField<Foam::vector>::New(foam_mesh.boundary()[id], var.internalField(), bcDict));

--- a/src/bcs/FoamBCBase.C
+++ b/src/bcs/FoamBCBase.C
@@ -4,15 +4,18 @@
 #include "MooseEnum.h"
 
 #include <Coupleable.h>
+#include <DimensionedField.H>
 #include <InputParameters.h>
 #include <MooseError.h>
 #include <MooseObject.h>
 #include <MooseTypes.h>
 #include <MooseVariableFieldBase.h>
 #include <Registry.h>
+#include <dimensionedScalar.H>
 #include <scalar.H>
 #include <scalarField.H>
 #include <volFieldsFwd.H>
+#include <basicThermo.H>
 
 #include <algorithm>
 #include <vector>
@@ -98,8 +101,12 @@ FoamBCBase::constructFoamScalarPatch(const std::string & patch_name, const std::
   {
     mooseError("Invalid _foam_bc_type");
   }
-  var.boundaryFieldRef().set(
-      id, Foam::fvPatchField<Foam::scalar>::New(patch, var.internalField(), bcDict));
+
+  var.boundaryFieldRef().set(id,
+                             Foam::fvPatchField<Foam::scalar>::New(
+                                 patch, var.boundaryField()[id].internalField(), bcDict));
+
+  updateEnergyPatch(patch_name, bc_type);
 }
 
 void
@@ -127,4 +134,43 @@ FoamBCBase::constructFoamVectorPatch(const std::string & patch_name, const std::
   }
   var.boundaryFieldRef().set(
       id, Foam::fvPatchField<Foam::vector>::New(patch, var.internalField(), bcDict));
+}
+
+void
+FoamBCBase::updateEnergyPatch(const std::string & patch_name, const std::string & bc_type)
+{
+  auto & foam_mesh = _mesh->fvMesh();
+  auto & var = foam_mesh.lookupObjectRef<Foam::volScalarField>(_foam_variable);
+  Foam::label id = foam_mesh.boundary().findIndex(patch_name);
+
+  auto thermos = foam_mesh.lookupClass<Foam::basicThermo>();
+
+  for (const auto & item : thermos)
+  {
+    auto & thermo = const_cast<Foam::basicThermo &>(*item);
+
+    // Only synchronize the thermo associated with this T field
+    if (&thermo.T() != &var)
+      continue;
+
+    auto & he = thermo.he(); // Returns e or h, depending on thermo configuration
+
+    Foam::dictionary dict;
+
+    if (bc_type == "fixedGradient")
+    {
+      dict.add("type", "gradientEnergy");
+      dict.add("gradient", "uniform 0");
+      dict.add("value", "uniform 0");
+    }
+    else if (bc_type == "fixedValue")
+    {
+      dict.add("type", "fixedEnergy");
+      dict.add("value", "uniform 0");
+    }
+
+    he.boundaryFieldRef().set(
+        id,
+        Foam::fvPatchField<Foam::scalar>::New(he.mesh().boundary()[id], he.internalField(), dict));
+  }
 }

--- a/src/bcs/FoamBCBase.C
+++ b/src/bcs/FoamBCBase.C
@@ -1,6 +1,7 @@
 
 #include "FoamBCBase.h"
 #include "FoamProblem.h"
+#include "MooseEnum.h"
 
 #include <Coupleable.h>
 #include <InputParameters.h>
@@ -9,6 +10,8 @@
 #include <MooseTypes.h>
 #include <MooseVariableFieldBase.h>
 #include <Registry.h>
+#include <scalar.H>
+#include <scalarField.H>
 #include <volFieldsFwd.H>
 
 #include <algorithm>
@@ -24,6 +27,8 @@ FoamBCBase::validParams()
                                               "Boundaries that the boundary condition applies to.");
   params.addRequiredParam<std::string>("foam_variable",
                                        "Name of a Foam field. e.g. T (temperature) U (velocity).");
+
+  params.addPrivateParam<std::string>("_foam_bc_type");
 
   params.registerSystemAttributeName("FoamBC");
   params.registerBase("FoamBC");
@@ -59,4 +64,67 @@ FoamBCBase::FoamBCBase(const InputParameters & params)
 
   if (_boundary.empty())
     _boundary = all_subdomain_names;
+
+  for (auto subdomain : _boundary)
+  {
+    if (_mesh->foamHasObject<Foam::volScalarField>(_foam_variable))
+      constructFoamScalarPatch(subdomain, params.get<std::string>("_foam_bc_type"));
+    else if (_mesh->foamHasObject<Foam::volVectorField>(_foam_variable))
+      constructFoamVectorPatch(subdomain, params.get<std::string>("_foam_bc_type"));
+    else
+      mooseError("Variable must have type scalar or vector.");
+  }
+}
+
+void
+FoamBCBase::constructFoamScalarPatch(const std::string & patch_name, const std::string & bc_type)
+{
+  auto & var = _mesh->fvMesh().lookupObjectRef<Foam::volScalarField>(_foam_variable);
+  Foam::label id = var.mesh().boundary().findIndex(patch_name);
+  auto & patch = var.mesh().boundary()[id];
+
+  Foam::dictionary bcDict;
+  if (bc_type == "fixedGradient")
+  {
+    bcDict.add("type", "fixedGradient");
+    bcDict.add("gradient", "uniform 0.");
+  }
+  else if (bc_type == "fixedValue")
+  {
+    bcDict.add("type", "fixedValue");
+    bcDict.add("value", "uniform 0.");
+  }
+  else
+  {
+    mooseError("Invalid _foam_bc_type");
+  }
+  var.boundaryFieldRef().set(
+      id, Foam::fvPatchField<Foam::scalar>::New(patch, var.internalField(), bcDict));
+}
+
+void
+FoamBCBase::constructFoamVectorPatch(const std::string & patch_name, const std::string & bc_type)
+{
+  auto & var = _mesh->fvMesh().lookupObjectRef<Foam::volVectorField>(_foam_variable);
+
+  Foam::label id = var.mesh().boundary().findIndex(patch_name);
+  auto & patch = var.mesh().boundary()[id];
+
+  Foam::dictionary bcDict;
+  if (bc_type == "fixedGradient")
+  {
+    bcDict.add("type", "fixedGradient");
+    bcDict.add("gradient", "uniform (0. 0. 0.)");
+  }
+  else if (bc_type == "fixedValue")
+  {
+    bcDict.add("type", "fixedValue");
+    bcDict.add("value", "uniform (0. 0. 0.)");
+  }
+  else
+  {
+    mooseError("Invalid _foam_bc_type");
+  }
+  var.boundaryFieldRef().set(
+      id, Foam::fvPatchField<Foam::vector>::New(patch, var.internalField(), bcDict));
 }

--- a/src/bcs/FoamBCBase.C
+++ b/src/bcs/FoamBCBase.C
@@ -1,24 +1,18 @@
 
 #include "FoamBCBase.h"
 #include "FoamProblem.h"
-#include "MooseEnum.h"
 
 #include <Coupleable.h>
-#include <DimensionedField.H>
 #include <InputParameters.h>
 #include <MooseError.h>
 #include <MooseObject.h>
 #include <MooseTypes.h>
 #include <MooseVariableFieldBase.h>
 #include <Registry.h>
-#include <dimensionedScalar.H>
-#include <scalar.H>
-#include <scalarField.H>
-#include <volFieldsFwd.H>
 #include <basicThermo.H>
 
-#include <algorithm>
 #include <vector>
+#include <volFieldsFwd.H>
 
 InputParameters
 FoamBCBase::validParams()
@@ -43,7 +37,8 @@ FoamBCBase::FoamBCBase(const InputParameters & params)
   : MooseObject(params),
     Coupleable(this, false),
     _foam_variable(params.get<std::string>("foam_variable")),
-    _boundary(params.get<std::vector<SubdomainName>>("boundary"))
+    _boundary(params.get<std::vector<SubdomainName>>("boundary")),
+    _patch_replaced(false)
 {
   auto * problem = dynamic_cast<FoamProblem *>(&_c_fe_problem);
   if (!problem)
@@ -82,21 +77,15 @@ FoamBCBase::FoamBCBase(const InputParameters & params)
 void
 FoamBCBase::constructFoamScalarPatch(const std::string & patch_name, const std::string & bc_type)
 {
-  auto & var = _mesh->fvMesh().lookupObjectRef<Foam::volScalarField>(_foam_variable);
-  Foam::label id = var.mesh().boundary().findIndex(patch_name);
-  auto & patch = var.mesh().boundary()[id];
+  auto & foam_mesh = _mesh->fvMesh();
+  auto & var = foam_mesh.lookupObjectRef<Foam::volScalarField>(_foam_variable);
+  Foam::label id = foam_mesh.boundary().findIndex(patch_name);
 
   if (var.boundaryField()[id].type() == bc_type)
     return;
 
-  mooseInfo("Overriding foam patch for boundary '",
-            patch_name,
-            "' for variable ",
-            _foam_variable,
-            " from ",
-            var.boundaryField()[id].type(),
-            " to ",
-            bc_type);
+  // Used by getInfoRow to report in the BC table that the patch as been replaced
+  _patch_replaced = true;
 
   Foam::dictionary bcDict;
   if (bc_type == "fixedGradient")
@@ -114,32 +103,26 @@ FoamBCBase::constructFoamScalarPatch(const std::string & patch_name, const std::
     mooseError("Invalid _foam_bc_type");
   }
 
-  var.boundaryFieldRef().set(id,
-                             Foam::fvPatchField<Foam::scalar>::New(
-                                 patch, var.boundaryField()[id].internalField(), bcDict));
+  var.boundaryFieldRef().set(
+      id,
+      Foam::fvPatchField<Foam::scalar>::New(
+          foam_mesh.boundary()[id], var.boundaryField()[id].internalField(), bcDict));
 
-  updateEnergyPatch(patch_name, bc_type);
+  // If temperature is replaced, internal energy or enthalpy typically needs replacing.
+  updateEnergyPatch(var, id, bc_type);
 }
 
 void
 FoamBCBase::constructFoamVectorPatch(const std::string & patch_name, const std::string & bc_type)
 {
-  auto & var = _mesh->fvMesh().lookupObjectRef<Foam::volVectorField>(_foam_variable);
-
-  Foam::label id = var.mesh().boundary().findIndex(patch_name);
-  auto & patch = var.mesh().boundary()[id];
+  auto & foam_mesh = _mesh->fvMesh();
+  auto & var = foam_mesh.lookupObjectRef<Foam::volVectorField>(_foam_variable);
+  Foam::label id = foam_mesh.boundary().findIndex(patch_name);
 
   if (var.boundaryField()[id].type() == bc_type)
     return;
 
-  mooseInfo("Overriding foam patch for boundary '",
-            patch_name,
-            "' for variable ",
-            _foam_variable,
-            " from ",
-            var.boundaryField()[id].type(),
-            " to ",
-            bc_type);
+  _patch_replaced = true;
 
   Foam::dictionary bcDict;
   if (bc_type == "fixedGradient")
@@ -157,17 +140,17 @@ FoamBCBase::constructFoamVectorPatch(const std::string & patch_name, const std::
     mooseError("Invalid _foam_bc_type");
   }
   var.boundaryFieldRef().set(
-      id, Foam::fvPatchField<Foam::vector>::New(patch, var.internalField(), bcDict));
+      id,
+      Foam::fvPatchField<Foam::vector>::New(foam_mesh.boundary()[id], var.internalField(), bcDict));
 }
 
 void
-FoamBCBase::updateEnergyPatch(const std::string & patch_name, const std::string & bc_type)
+FoamBCBase::updateEnergyPatch(const Foam::volScalarField & var,
+                              Foam::label id,
+                              const std::string & bc_type)
 {
-  auto & foam_mesh = _mesh->fvMesh();
-  auto & var = foam_mesh.lookupObjectRef<Foam::volScalarField>(_foam_variable);
-  Foam::label id = foam_mesh.boundary().findIndex(patch_name);
 
-  auto thermos = foam_mesh.lookupClass<Foam::basicThermo>();
+  auto thermos = var.mesh().lookupClass<Foam::basicThermo>();
 
   for (const auto & item : thermos)
   {

--- a/src/bcs/FoamBCBase.C
+++ b/src/bcs/FoamBCBase.C
@@ -86,6 +86,18 @@ FoamBCBase::constructFoamScalarPatch(const std::string & patch_name, const std::
   Foam::label id = var.mesh().boundary().findIndex(patch_name);
   auto & patch = var.mesh().boundary()[id];
 
+  if (var.boundaryField()[id].type() == bc_type)
+    return;
+
+  mooseInfo("Overriding foam patch for boundary '",
+            patch_name,
+            "' for variable ",
+            _foam_variable,
+            " from ",
+            var.boundaryField()[id].type(),
+            " to ",
+            bc_type);
+
   Foam::dictionary bcDict;
   if (bc_type == "fixedGradient")
   {
@@ -116,6 +128,18 @@ FoamBCBase::constructFoamVectorPatch(const std::string & patch_name, const std::
 
   Foam::label id = var.mesh().boundary().findIndex(patch_name);
   auto & patch = var.mesh().boundary()[id];
+
+  if (var.boundaryField()[id].type() == bc_type)
+    return;
+
+  mooseInfo("Overriding foam patch for boundary '",
+            patch_name,
+            "' for variable ",
+            _foam_variable,
+            " from ",
+            var.boundaryField()[id].type(),
+            " to ",
+            bc_type);
 
   Foam::dictionary bcDict;
   if (bc_type == "fixedGradient")

--- a/src/bcs/FoamBCBase.C
+++ b/src/bcs/FoamBCBase.C
@@ -14,6 +14,23 @@
 #include <vector>
 #include <volFieldsFwd.H>
 
+namespace
+{
+std::string
+bc_type_to_string(FoamBCType const & bc_type)
+{
+  switch (bc_type)
+  {
+    case FoamBCType::fixedValue:
+      return "fixedValue";
+    case FoamBCType::fixedGradient:
+      return "fixedGradient";
+    default:
+      mooseError("Unhandled (should be impossible)");
+  }
+}
+}
+
 InputParameters
 FoamBCBase::validParams()
 {
@@ -31,7 +48,7 @@ FoamBCBase::validParams()
   return params;
 }
 
-FoamBCBase::FoamBCBase(const InputParameters & params, const std::string & bc_type)
+FoamBCBase::FoamBCBase(const InputParameters & params, const FoamBCType bc_type)
   : MooseObject(params),
     Coupleable(this, false),
     _foam_variable(params.get<std::string>("foam_variable")),
@@ -61,10 +78,6 @@ FoamBCBase::FoamBCBase(const InputParameters & params, const std::string & bc_ty
   if (_boundary.empty())
     _boundary = all_subdomain_names;
 
-  // Check validity of BC Type
-  if (_foam_bc_types.find(bc_type) == _foam_bc_types.items().end())
-    mooseError("'", bc_type, "' invalid Foam BC Type.");
-
   for (auto subdomain : _boundary)
   {
     if (_mesh->foamHasObject<Foam::volScalarField>(_foam_variable))
@@ -77,27 +90,26 @@ FoamBCBase::FoamBCBase(const InputParameters & params, const std::string & bc_ty
 }
 
 void
-FoamBCBase::constructFoamScalarPatch(const std::string & patch_name, const std::string & bc_type)
+FoamBCBase::constructFoamScalarPatch(const std::string & patch_name, const FoamBCType bc_type)
 {
   auto & foam_mesh = _mesh->fvMesh();
   auto & var = foam_mesh.lookupObjectRef<Foam::volScalarField>(_foam_variable);
   Foam::label id = foam_mesh.boundary().findIndex(patch_name);
 
-  if (bc_type == var.boundaryField()[id].type())
+  if (bc_type_to_string(bc_type) == var.boundaryField()[id].type())
     return;
 
   // Used by getInfoRow to report in the BC table that the patch as been replaced
   _patch_replaced = true;
 
   Foam::dictionary bcDict;
-  if (bc_type == "fixedGradient")
+  bcDict.add("type", bc_type_to_string(bc_type));
+  if (bc_type == FoamBCType::fixedGradient)
   {
-    bcDict.add("type", "fixedGradient");
     bcDict.add("gradient", "uniform 0.");
   }
-  else if (bc_type == "fixedValue")
+  else if (bc_type == FoamBCType::fixedValue)
   {
-    bcDict.add("type", "fixedValue");
     bcDict.add("value", "uniform 0.");
   }
 
@@ -111,26 +123,25 @@ FoamBCBase::constructFoamScalarPatch(const std::string & patch_name, const std::
 }
 
 void
-FoamBCBase::constructFoamVectorPatch(const std::string & patch_name, const std::string & bc_type)
+FoamBCBase::constructFoamVectorPatch(const std::string & patch_name, const FoamBCType bc_type)
 {
   auto & foam_mesh = _mesh->fvMesh();
   auto & var = foam_mesh.lookupObjectRef<Foam::volVectorField>(_foam_variable);
   Foam::label id = foam_mesh.boundary().findIndex(patch_name);
 
-  if (bc_type == var.boundaryField()[id].type())
+  if (bc_type_to_string(bc_type) == var.boundaryField()[id].type())
     return;
 
   _patch_replaced = true;
 
   Foam::dictionary bcDict;
-  if (bc_type == "fixedGradient")
+  bcDict.add("type", bc_type_to_string(bc_type));
+  if (bc_type == FoamBCType::fixedGradient)
   {
-    bcDict.add("type", "fixedGradient");
     bcDict.add("gradient", "uniform (0. 0. 0.)");
   }
-  else if (bc_type == "fixedValue")
+  else if (bc_type == FoamBCType::fixedValue)
   {
-    bcDict.add("type", "fixedValue");
     bcDict.add("value", "uniform (0. 0. 0.)");
   }
 
@@ -142,7 +153,7 @@ FoamBCBase::constructFoamVectorPatch(const std::string & patch_name, const std::
 void
 FoamBCBase::updateEnergyPatch(const Foam::volScalarField & var,
                               Foam::label id,
-                              const std::string & bc_type)
+                              const FoamBCType bc_type)
 {
 
   auto thermos = var.mesh().lookupClass<Foam::basicThermo>();
@@ -159,13 +170,13 @@ FoamBCBase::updateEnergyPatch(const Foam::volScalarField & var,
 
     Foam::dictionary dict;
 
-    if (bc_type == "fixedGradient")
+    if (bc_type == FoamBCType::fixedGradient)
     {
       dict.add("type", "gradientEnergy");
       dict.add("gradient", "uniform 0");
       dict.add("value", "uniform 0");
     }
-    else if (bc_type == "fixedValue")
+    else if (bc_type == FoamBCType::fixedValue)
     {
       dict.add("type", "fixedEnergy");
       dict.add("value", "uniform 0");

--- a/src/bcs/FoamDiffusionFluxBC.C
+++ b/src/bcs/FoamDiffusionFluxBC.C
@@ -16,6 +16,8 @@ FoamDiffusionFluxBC::validParams()
   auto params = FoamVariableBCBase::validParams();
   params.addParam<std::string>(
       "diffusivity", "kappa", "Diffusivity for BC, defaults to kappa, the thermal conducitivity.");
+  params.set<std::string>("_foam_bc_type") = "fixedGradient";
+
   params.addClassDescription("A FoamBC that imposes a fixed gradient boundary condition "
                              "on the OpenFOAM simulation");
   return params;

--- a/src/bcs/FoamDiffusionFluxBC.C
+++ b/src/bcs/FoamDiffusionFluxBC.C
@@ -16,7 +16,6 @@ FoamDiffusionFluxBC::validParams()
   auto params = FoamVariableBCBase::validParams();
   params.addParam<std::string>(
       "diffusivity", "kappa", "Diffusivity for BC, defaults to kappa, the thermal conducitivity.");
-  params.set<std::string>("_foam_bc_type") = "fixedGradient";
 
   params.addClassDescription("A FoamBC that imposes a fixed gradient boundary condition "
                              "on the OpenFOAM simulation");
@@ -24,7 +23,7 @@ FoamDiffusionFluxBC::validParams()
 }
 
 FoamDiffusionFluxBC::FoamDiffusionFluxBC(const InputParameters & params)
-  : FoamVariableBCBase(params), _diffusivity(getParam<std::string>("diffusivity"))
+  : FoamVariableBCBase(params, "fixedGradient"), _diffusivity(getParam<std::string>("diffusivity"))
 {
   if (!_mesh->fvMesh().foundObject<Foam::volScalarField>(_diffusivity))
   {

--- a/src/bcs/FoamDiffusionFluxBC.C
+++ b/src/bcs/FoamDiffusionFluxBC.C
@@ -1,4 +1,5 @@
 
+#include "FoamBCBase.h"
 #include "FoamDiffusionFluxBC.h"
 #include "FoamVariableBCBase.h"
 #include "MooseError.h"
@@ -23,7 +24,8 @@ FoamDiffusionFluxBC::validParams()
 }
 
 FoamDiffusionFluxBC::FoamDiffusionFluxBC(const InputParameters & params)
-  : FoamVariableBCBase(params, "fixedGradient"), _diffusivity(getParam<std::string>("diffusivity"))
+  : FoamVariableBCBase(params, FoamBCType::fixedGradient),
+    _diffusivity(getParam<std::string>("diffusivity"))
 {
   if (!_mesh->fvMesh().foundObject<Foam::volScalarField>(_diffusivity))
   {

--- a/src/bcs/FoamDiffusionFluxPostprocessorBC.C
+++ b/src/bcs/FoamDiffusionFluxPostprocessorBC.C
@@ -12,6 +12,8 @@ FoamDiffusionFluxPostprocessorBC::validParams()
   auto params = FoamPostprocessorBCBase::validParams();
   params.addParam<std::string>(
       "diffusivity", "kappa", "Diffusivity for BC, defaults to kappa, the thermal conducitivity.");
+  params.set<std::string>("_foam_bc_type") = "fixedGradient";
+
   return params;
 }
 

--- a/src/bcs/FoamDiffusionFluxPostprocessorBC.C
+++ b/src/bcs/FoamDiffusionFluxPostprocessorBC.C
@@ -12,13 +12,13 @@ FoamDiffusionFluxPostprocessorBC::validParams()
   auto params = FoamPostprocessorBCBase::validParams();
   params.addParam<std::string>(
       "diffusivity", "kappa", "Diffusivity for BC, defaults to kappa, the thermal conducitivity.");
-  params.set<std::string>("_foam_bc_type") = "fixedGradient";
 
   return params;
 }
 
 FoamDiffusionFluxPostprocessorBC::FoamDiffusionFluxPostprocessorBC(const InputParameters & params)
-  : FoamPostprocessorBCBase(params), _diffusivity(getParam<std::string>("diffusivity"))
+  : FoamPostprocessorBCBase(params, "fixedGradient"),
+    _diffusivity(getParam<std::string>("diffusivity"))
 {
   if (!_mesh->fvMesh().foundObject<Foam::volScalarField>(_diffusivity))
   {

--- a/src/bcs/FoamDiffusionFluxPostprocessorBC.C
+++ b/src/bcs/FoamDiffusionFluxPostprocessorBC.C
@@ -1,3 +1,4 @@
+#include "FoamBCBase.h"
 #include "FoamDiffusionFluxPostprocessorBC.h"
 #include "FoamPostprocessorBCBase.h"
 #include "PstreamReduceOps.H"
@@ -17,7 +18,7 @@ FoamDiffusionFluxPostprocessorBC::validParams()
 }
 
 FoamDiffusionFluxPostprocessorBC::FoamDiffusionFluxPostprocessorBC(const InputParameters & params)
-  : FoamPostprocessorBCBase(params, "fixedGradient"),
+  : FoamPostprocessorBCBase(params, FoamBCType::fixedGradient),
     _diffusivity(getParam<std::string>("diffusivity"))
 {
   if (!_mesh->fvMesh().foundObject<Foam::volScalarField>(_diffusivity))

--- a/src/bcs/FoamFixedGradientBC.C
+++ b/src/bcs/FoamFixedGradientBC.C
@@ -11,6 +11,8 @@ InputParameters
 FoamFixedGradientBC::validParams()
 {
   auto params = FoamVariableBCBase::validParams();
+  params.set<std::string>("_foam_bc_type") = "fixedGradient";
+
   params.addClassDescription("A FoamBC that imposes a fixed gradient boundary condition "
                              "on the OpenFOAM simulation");
   return params;

--- a/src/bcs/FoamFixedGradientBC.C
+++ b/src/bcs/FoamFixedGradientBC.C
@@ -26,8 +26,6 @@ FoamFixedGradientBC::FoamFixedGradientBC(const InputParameters & parameters)
 void
 FoamFixedGradientBC::imposeBoundaryCondition()
 {
-  auto & foam_mesh = _mesh->fvMesh();
-
   // Get subdomains this FoamBC acts on
   // TODO: replace with BoundaryRestriction member functions once FoamMesh is updated
   auto subdomains = _mesh->getSubdomainIDs(_boundary);

--- a/src/bcs/FoamFixedGradientBC.C
+++ b/src/bcs/FoamFixedGradientBC.C
@@ -11,7 +11,6 @@ InputParameters
 FoamFixedGradientBC::validParams()
 {
   auto params = FoamVariableBCBase::validParams();
-  params.set<std::string>("_foam_bc_type") = "fixedGradient";
 
   params.addClassDescription("A FoamBC that imposes a fixed gradient boundary condition "
                              "on the OpenFOAM simulation");
@@ -19,7 +18,7 @@ FoamFixedGradientBC::validParams()
 }
 
 FoamFixedGradientBC::FoamFixedGradientBC(const InputParameters & parameters)
-  : FoamVariableBCBase(parameters)
+  : FoamVariableBCBase(parameters, "fixedGradient")
 {
 }
 

--- a/src/bcs/FoamFixedGradientBC.C
+++ b/src/bcs/FoamFixedGradientBC.C
@@ -18,7 +18,7 @@ FoamFixedGradientBC::validParams()
 }
 
 FoamFixedGradientBC::FoamFixedGradientBC(const InputParameters & parameters)
-  : FoamVariableBCBase(parameters, "fixedGradient")
+  : FoamVariableBCBase(parameters, FoamBCType::fixedGradient)
 {
 }
 

--- a/src/bcs/FoamFixedGradientPostprocessorBC.C
+++ b/src/bcs/FoamFixedGradientPostprocessorBC.C
@@ -9,13 +9,12 @@ InputParameters
 FoamFixedGradientPostprocessorBC::validParams()
 {
   auto params = FoamPostprocessorBCBase::validParams();
-  params.set<std::string>("_foam_bc_type") = "fixedGradient";
 
   return params;
 }
 
 FoamFixedGradientPostprocessorBC::FoamFixedGradientPostprocessorBC(const InputParameters & params)
-  : FoamPostprocessorBCBase(params)
+  : FoamPostprocessorBCBase(params, "fixedGradient")
 {
 }
 

--- a/src/bcs/FoamFixedGradientPostprocessorBC.C
+++ b/src/bcs/FoamFixedGradientPostprocessorBC.C
@@ -9,6 +9,8 @@ InputParameters
 FoamFixedGradientPostprocessorBC::validParams()
 {
   auto params = FoamPostprocessorBCBase::validParams();
+  params.set<std::string>("_foam_bc_type") = "fixedGradient";
+
   return params;
 }
 

--- a/src/bcs/FoamFixedGradientPostprocessorBC.C
+++ b/src/bcs/FoamFixedGradientPostprocessorBC.C
@@ -14,7 +14,7 @@ FoamFixedGradientPostprocessorBC::validParams()
 }
 
 FoamFixedGradientPostprocessorBC::FoamFixedGradientPostprocessorBC(const InputParameters & params)
-  : FoamPostprocessorBCBase(params, "fixedGradient")
+  : FoamPostprocessorBCBase(params, FoamBCType::fixedGradient)
 {
 }
 

--- a/src/bcs/FoamFixedValueBC.C
+++ b/src/bcs/FoamFixedValueBC.C
@@ -9,7 +9,6 @@ InputParameters
 FoamFixedValueBC::validParams()
 {
   auto params = FoamVariableBCBase::validParams();
-  params.set<std::string>("_foam_bc_type") = "fixedValue";
 
   params.addClassDescription("A FoamBC that imposes a fixed value dirichlet boundary condition "
                              "on the OpenFOAM simulation");
@@ -17,7 +16,7 @@ FoamFixedValueBC::validParams()
 }
 
 FoamFixedValueBC::FoamFixedValueBC(const InputParameters & parameters)
-  : FoamVariableBCBase(parameters)
+  : FoamVariableBCBase(parameters, "fixedValue")
 {
 }
 

--- a/src/bcs/FoamFixedValueBC.C
+++ b/src/bcs/FoamFixedValueBC.C
@@ -9,6 +9,8 @@ InputParameters
 FoamFixedValueBC::validParams()
 {
   auto params = FoamVariableBCBase::validParams();
+  params.set<std::string>("_foam_bc_type") = "fixedValue";
+
   params.addClassDescription("A FoamBC that imposes a fixed value dirichlet boundary condition "
                              "on the OpenFOAM simulation");
   return params;

--- a/src/bcs/FoamFixedValueBC.C
+++ b/src/bcs/FoamFixedValueBC.C
@@ -16,7 +16,7 @@ FoamFixedValueBC::validParams()
 }
 
 FoamFixedValueBC::FoamFixedValueBC(const InputParameters & parameters)
-  : FoamVariableBCBase(parameters, "fixedValue")
+  : FoamVariableBCBase(parameters, FoamBCType::fixedValue)
 {
 }
 

--- a/src/bcs/FoamFixedValuePosprocessorBC.C
+++ b/src/bcs/FoamFixedValuePosprocessorBC.C
@@ -6,7 +6,10 @@ registerMooseObject("hippoApp", FoamFixedValuePostprocessorBC);
 InputParameters
 FoamFixedValuePostprocessorBC::validParams()
 {
-  return FoamPostprocessorBCBase::validParams();
+  auto params = FoamPostprocessorBCBase::validParams();
+  params.set<std::string>("_foam_bc_type") = "fixedValue";
+
+  return params;
 }
 
 FoamFixedValuePostprocessorBC::FoamFixedValuePostprocessorBC(const InputParameters & params)

--- a/src/bcs/FoamFixedValuePosprocessorBC.C
+++ b/src/bcs/FoamFixedValuePosprocessorBC.C
@@ -7,13 +7,12 @@ InputParameters
 FoamFixedValuePostprocessorBC::validParams()
 {
   auto params = FoamPostprocessorBCBase::validParams();
-  params.set<std::string>("_foam_bc_type") = "fixedValue";
 
   return params;
 }
 
 FoamFixedValuePostprocessorBC::FoamFixedValuePostprocessorBC(const InputParameters & params)
-  : FoamPostprocessorBCBase(params)
+  : FoamPostprocessorBCBase(params, "fixedValue")
 {
 }
 

--- a/src/bcs/FoamFixedValuePosprocessorBC.C
+++ b/src/bcs/FoamFixedValuePosprocessorBC.C
@@ -12,7 +12,7 @@ FoamFixedValuePostprocessorBC::validParams()
 }
 
 FoamFixedValuePostprocessorBC::FoamFixedValuePostprocessorBC(const InputParameters & params)
-  : FoamPostprocessorBCBase(params, "fixedValue")
+  : FoamPostprocessorBCBase(params, FoamBCType::fixedValue)
 {
 }
 

--- a/src/bcs/FoamMassFlowRateInletBC.C
+++ b/src/bcs/FoamMassFlowRateInletBC.C
@@ -14,6 +14,7 @@ FoamMassFlowRateInletBC::validParams()
   params.addParam<Real>("scale_factor", 1., "Scale factor multiply mass flow rate pp_name by.");
   params.suppressParameter<std::string>("foam_variable");
   params.set<std::string>("foam_variable") = "U";
+  params.set<std::string>("_foam_bc_type") = "fixedValue";
 
   return params;
 }

--- a/src/bcs/FoamMassFlowRateInletBC.C
+++ b/src/bcs/FoamMassFlowRateInletBC.C
@@ -19,7 +19,8 @@ FoamMassFlowRateInletBC::validParams()
 }
 
 FoamMassFlowRateInletBC::FoamMassFlowRateInletBC(const InputParameters & params)
-  : FoamPostprocessorBCBase(params, "fixedValue"), _scale_factor(params.get<Real>("scale_factor"))
+  : FoamPostprocessorBCBase(params, FoamBCType::fixedValue),
+    _scale_factor(params.get<Real>("scale_factor"))
 {
 }
 

--- a/src/bcs/FoamMassFlowRateInletBC.C
+++ b/src/bcs/FoamMassFlowRateInletBC.C
@@ -14,13 +14,12 @@ FoamMassFlowRateInletBC::validParams()
   params.addParam<Real>("scale_factor", 1., "Scale factor multiply mass flow rate pp_name by.");
   params.suppressParameter<std::string>("foam_variable");
   params.set<std::string>("foam_variable") = "U";
-  params.set<std::string>("_foam_bc_type") = "fixedValue";
 
   return params;
 }
 
 FoamMassFlowRateInletBC::FoamMassFlowRateInletBC(const InputParameters & params)
-  : FoamPostprocessorBCBase(params), _scale_factor(params.get<Real>("scale_factor"))
+  : FoamPostprocessorBCBase(params, "fixedValue"), _scale_factor(params.get<Real>("scale_factor"))
 {
 }
 

--- a/src/bcs/FoamPostprocessorBCBase.C
+++ b/src/bcs/FoamPostprocessorBCBase.C
@@ -6,7 +6,6 @@
 #include "MooseTypes.h"
 #include "PostprocessorInterface.h"
 #include "Receiver.h"
-#include <tuple>
 
 InputParameters
 FoamPostprocessorBCBase::validParams()
@@ -19,8 +18,9 @@ FoamPostprocessorBCBase::validParams()
   return params;
 }
 
-FoamPostprocessorBCBase::FoamPostprocessorBCBase(const InputParameters & params)
-  : FoamBCBase(params),
+FoamPostprocessorBCBase::FoamPostprocessorBCBase(const InputParameters & params,
+                                                 const std::string & bc_type)
+  : FoamBCBase(params, bc_type),
     PostprocessorInterface(this),
     _pp_name((params.isParamSetByUser("pp_name")) ? params.get<PostprocessorName>("pp_name")
                                                   : _name),

--- a/src/bcs/FoamPostprocessorBCBase.C
+++ b/src/bcs/FoamPostprocessorBCBase.C
@@ -37,5 +37,6 @@ FoamPostprocessorBCBase::getInfoRow() const
                          type(),
                          foamVariable(),
                          moosePostprocessor(),
-                         Hippo::internal::listFromVector(boundary()));
+                         Hippo::internal::listFromVector(boundary()),
+                         _patch_replaced ? "yes" : "no");
 }

--- a/src/bcs/FoamPostprocessorBCBase.C
+++ b/src/bcs/FoamPostprocessorBCBase.C
@@ -19,7 +19,7 @@ FoamPostprocessorBCBase::validParams()
 }
 
 FoamPostprocessorBCBase::FoamPostprocessorBCBase(const InputParameters & params,
-                                                 const std::string & bc_type)
+                                                 const FoamBCType bc_type)
   : FoamBCBase(params, bc_type),
     PostprocessorInterface(this),
     _pp_name((params.isParamSetByUser("pp_name")) ? params.get<PostprocessorName>("pp_name")

--- a/src/bcs/FoamVariableBCBase.C
+++ b/src/bcs/FoamVariableBCBase.C
@@ -55,8 +55,12 @@ BCInfoTableRow
 FoamVariableBCBase::getInfoRow() const
 {
   // List info about BC
-  return std::make_tuple(
-      name(), type(), foamVariable(), mooseVariable(), Hippo::internal::listFromVector(boundary()));
+  return std::make_tuple(name(),
+                         type(),
+                         foamVariable(),
+                         mooseVariable(),
+                         Hippo::internal::listFromVector(boundary()),
+                         _patch_replaced ? "yes" : "no");
 }
 
 Real

--- a/src/bcs/FoamVariableBCBase.C
+++ b/src/bcs/FoamVariableBCBase.C
@@ -30,8 +30,8 @@ FoamVariableBCBase::validParams()
   return params;
 }
 
-FoamVariableBCBase::FoamVariableBCBase(const InputParameters & params)
-  : FoamBCBase(params), _moose_var()
+FoamVariableBCBase::FoamVariableBCBase(const InputParameters & params, const std::string & bc_type)
+  : FoamBCBase(params, bc_type), _moose_var()
 {
 }
 

--- a/src/bcs/FoamVariableBCBase.C
+++ b/src/bcs/FoamVariableBCBase.C
@@ -30,7 +30,7 @@ FoamVariableBCBase::validParams()
   return params;
 }
 
-FoamVariableBCBase::FoamVariableBCBase(const InputParameters & params, const std::string & bc_type)
+FoamVariableBCBase::FoamVariableBCBase(const InputParameters & params, const FoamBCType bc_type)
   : FoamBCBase(params, bc_type), _moose_var()
 {
 }

--- a/src/problems/FoamProblem.C
+++ b/src/problems/FoamProblem.C
@@ -131,13 +131,13 @@ FoamProblem::verifyFoamBCs()
     unique_vars.insert(bc->foamVariable());
 
   // Create table for printing BC information
-  VariadicTable<std::string, std::string, std::string, std::string, std::string> vt({
-      "FoamBC name",
-      "Type",
-      "Foam variable",
-      "Moose variable/postprocessor",
-      "Boundaries",
-  });
+  VariadicTable<std::string, std::string, std::string, std::string, std::string, std::string> vt(
+      {"FoamBC name",
+       "Type",
+       "Foam variable",
+       "Moose variable/postprocessor",
+       "Boundaries",
+       "Patch replaced?"});
 
   for (auto var : unique_vars)
   {
@@ -153,8 +153,8 @@ FoamProblem::verifyFoamBCs()
         auto && boundary = bc->boundary();
         used_bcs.insert(used_bcs.end(), boundary.begin(), boundary.end());
         // List info about BC
-        auto [name, type, foam_var, moose_var, boundaries] = bc->getInfoRow();
-        vt.addRow(name, type, foam_var, moose_var, boundaries);
+        auto [name, type, foam_var, moose_var, boundaries, patch_replaced] = bc->getInfoRow();
+        vt.addRow(name, type, foam_var, moose_var, boundaries, patch_replaced);
       }
     }
 
@@ -176,7 +176,7 @@ FoamProblem::verifyFoamBCs()
         unused_bcs.push_back(bc);
     }
     if (unused_bcs.size() > 0)
-      vt.addRow("", "UnusedBoundaries", "", "", Hippo::internal::listFromVector(unused_bcs));
+      vt.addRow("", "UnusedBoundaries", "", "", Hippo::internal::listFromVector(unused_bcs), "");
   }
   vt.print(_console);
 }

--- a/test/include/bcs/FoamTestBC.h
+++ b/test/include/bcs/FoamTestBC.h
@@ -4,6 +4,7 @@
 class FoamTestBC : public FoamVariableBCBase
 {
 public:
+  static InputParameters validParams();
   explicit FoamTestBC(const InputParameters & params) : FoamVariableBCBase(params) {};
 
   void imposeBoundaryCondition() {};

--- a/test/include/bcs/FoamTestBC.h
+++ b/test/include/bcs/FoamTestBC.h
@@ -5,7 +5,8 @@ class FoamTestBC : public FoamVariableBCBase
 {
 public:
   static InputParameters validParams();
-  explicit FoamTestBC(const InputParameters & params) : FoamVariableBCBase(params, "fixedValue") {};
+  explicit FoamTestBC(const InputParameters & params)
+    : FoamVariableBCBase(params, FoamBCType::fixedValue) {};
 
   void imposeBoundaryCondition() {};
 };

--- a/test/include/bcs/FoamTestBC.h
+++ b/test/include/bcs/FoamTestBC.h
@@ -5,7 +5,7 @@ class FoamTestBC : public FoamVariableBCBase
 {
 public:
   static InputParameters validParams();
-  explicit FoamTestBC(const InputParameters & params) : FoamVariableBCBase(params) {};
+  explicit FoamTestBC(const InputParameters & params) : FoamVariableBCBase(params, "fixedValue") {};
 
   void imposeBoundaryCondition() {};
 };

--- a/test/src/bcs/FoamTestBC.C
+++ b/test/src/bcs/FoamTestBC.C
@@ -6,6 +6,5 @@ InputParameters
 FoamTestBC::validParams()
 {
   auto params = FoamVariableBCBase::validParams();
-  params.set<std::string>("_foam_bc_type") = "fixedValue";
   return params;
 }

--- a/test/src/bcs/FoamTestBC.C
+++ b/test/src/bcs/FoamTestBC.C
@@ -1,3 +1,11 @@
 #include "FoamTestBC.h"
 
 registerMooseObject("hippoTestApp", FoamTestBC);
+
+InputParameters
+FoamTestBC::validParams()
+{
+  auto params = FoamVariableBCBase::validParams();
+  params.set<std::string>("_foam_bc_type") = "fixedValue";
+  return params;
+}

--- a/test/tests/bcs/fixed_value/foam/0/T
+++ b/test/tests/bcs/fixed_value/foam/0/T
@@ -25,6 +25,7 @@ boundaryField
         type            fixedValue;
         value           uniform 0.;
     }
+    // Use fixed gradient to check Hippo's ability to override this type
     right
     {
         type            fixedGradient;

--- a/test/tests/bcs/fixed_value/foam/0/T
+++ b/test/tests/bcs/fixed_value/foam/0/T
@@ -27,8 +27,8 @@ boundaryField
     }
     right
     {
-        type            fixedValue;
-        value           uniform 0.;
+        type            fixedGradient;
+        gradient           uniform 0.;
     }
     top
     {

--- a/test/tests/bcs/fixed_value/tests
+++ b/test/tests/bcs/fixed_value/tests
@@ -1,5 +1,6 @@
 [Tests]
     [foam_bc_action_test]
+        requirement = "Check imposition of fixed value BCs and ability to override underlying Foam BC types."
         [setup]
             type = RunCommand
             command = 'bash -c "foamCleanCase -case foam && blockMesh -case foam && decomposePar -force -case foam"'

--- a/test/tests/bcs/laplace_fixed_gradient/foam/0/T
+++ b/test/tests/bcs/laplace_fixed_gradient/foam/0/T
@@ -27,8 +27,8 @@ boundaryField
     }
     right
     {
-        type            fixedGradient;
-        gradient          uniform 1.;
+        type            fixedValue;
+        value           uniform 0.;
     }
     top
     {

--- a/test/tests/bcs/mass_flow_rate/foam/0/U
+++ b/test/tests/bcs/mass_flow_rate/foam/0/U
@@ -26,6 +26,11 @@ boundaryField
         type            fixedValue;
         value           $internalField;
     }
+    left
+    {
+        type            fixedGradient;
+        gradient              uniform (0 0 0);
+    }
 }
 
 // ************************************************************************* //

--- a/test/tests/timesteppers/foam_controlled_tstep_cfl_insert/fluid.i
+++ b/test/tests/timesteppers/foam_controlled_tstep_cfl_insert/fluid.i
@@ -10,34 +10,12 @@
   []
 []
 
-[FoamBCs]
-  [T]
-    type = FoamFixedValueBC
-    foam_variable = T
-    initial_condition = 111
-  []
-[]
-
-[FoamVariables]
-  [foam_T]
-    type = FoamVariableField
-    foam_variable = T
-  []
-  [foam_hf]
-    type = FoamFunctionObject
-    foam_variable = wallHeatFlux
-  []
-[]
-
 [Problem]
   type=FoamProblem
 []
 
 [Executioner]
   type = Transient
-  solve_type = 'PJFNK'
-  petsc_options_iname = '-pc_type -pc_hypre_type'
-  petsc_options_value = 'hypre boomeramg'
 
   end_time=0.51
   [TimeStepper]

--- a/test/tests/timesteppers/foam_controlled_tstep_cfl_insert/test.py
+++ b/test/tests/timesteppers/foam_controlled_tstep_cfl_insert/test.py
@@ -16,6 +16,7 @@ class TestFoamTimeStepper(TestCase):
         for dir in [0.1, 0.2, 0.3, 0.4, 0.5]:
             assert str(dir) in dirs, f"{dir} resutlts folder not found"
 
+        cutbacks = 0
         dirs = sorted(float(dir) for dir in dirs)
         for dir in [0.1, 0.2, 0.3, 0.4]:
             idx = dirs.index(dir)
@@ -23,9 +24,16 @@ class TestFoamTimeStepper(TestCase):
             dt1 = dirs[idx] - dirs[idx - 1]
             dt2 = dirs[idx + 1] - dirs[idx]
 
-            assert dt2 > 1.25 * dt1 and dt0 > 1.25 * dt1, (
-                "Check recovery from cutback works properly"
-            )
+            # only run the test for dir if the initial cutback is large enough
+            if dt1 > 0.8 * dt0:
+                continue
+
+            cutbacks += 1
+            assert dt2 > 1.25 * dt1, "Check recovery from cutback works properly"
+
+        assert cutbacks > 0, (
+            "Test has not worked properly there should be at least 1 cutback"
+        )
 
     def test_force_no_cfl(self):
         """Checks that CFL is not used if dt is overriden"""


### PR DESCRIPTION
## Summary

Changes `FoamBCBase` to set the correct fvPatchField when it is initialised

## Related Issue

Resolves #126 

## Checklist

- [x] Functionality implememented
  - [x] Make sure energy BCs updated if `T` is updated 
- [x] Some of the existing boundary condition tests updated to test the switch
  - [x] `laplace_fixed_gradient`, `fixed_value` and `mass_flow_rate`
- [x] Fixed bugs in timestepper class associated with the update  
- [x] Existing docs didn't mention need to set the correct underlying BC (as far as I can see)