### PR TITLE
Permit different versions of MPI and switching between different OpenFOAM versions in dev containers

### DIFF
--- a/.github/workflows/deploy-apptainer-dev.yml
+++ b/.github/workflows/deploy-apptainer-dev.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Login to remote
         run: apptainer registry login -u ${{ secrets.QUAY_ID }} -p ${{ secrets.QUAY_TOKEN }} oras://quay.io
       - name: Substitute container
-        run: MPI=${{ matrix.mpi }}  envsubst '${MPI}' < apptainer/hippo_dev.def.in > apptainer/hippo_dev.def
+        run: MPI=${{ matrix.mpi }}  envsubst '${MPI}' < apptainer/hippo-dev.def.in > apptainer/hippo-dev.def
       - name: build container
         run: apptainer build --build-arg OPENFOAM_VERSION=${{ matrix.openfoam_version }} hippo-dev.sif apptainer/hippo-dev.def
       - name: push container

--- a/.github/workflows/deploy-apptainer-dev.yml
+++ b/.github/workflows/deploy-apptainer-dev.yml
@@ -27,4 +27,4 @@ jobs:
       - name: build container
         run: apptainer build --build-arg OPENFOAM_VERSION=${{ matrix.openfoam_version }} hippo-dev.sif apptainer/hippo-dev.def
       - name: push container
-        run: apptainer push hippo-dev.sif oras://quay.io/ukaea/hippo_${{ matrix.mpi }}_OF${{ matrix.openfoam_version }}:dev-${GITHUB_SHA::10}
+        run: apptainer push hippo-dev.sif oras://quay.io/ukaea/hippo_${{ matrix.mpi }}_of${{ matrix.openfoam_version }}:dev-${GITHUB_SHA::10}

--- a/.github/workflows/deploy-apptainer-dev.yml
+++ b/.github/workflows/deploy-apptainer-dev.yml
@@ -12,7 +12,7 @@ jobs:
       github.actor == 'k-collie'
     runs-on: ubuntu-latest
     matrix:
-      openfoam_version: [12, 13]
+      openfoam_version: [13, 14]
       mpi: [openmpi, mpich]
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/deploy-apptainer-dev.yml
+++ b/.github/workflows/deploy-apptainer-dev.yml
@@ -27,4 +27,4 @@ jobs:
       - name: build container
         run: apptainer build --build-arg OPENFOAM_VERSION=${{ matrix.openfoam_version }} hippo-dev.sif apptainer/hippo-dev.def
       - name: push container
-        run: apptainer push hippo-dev.sif oras://quay.io/ukaea/hippo_${{ matrix.mpi }}_of${{ matrix.openfoam_version }}:dev-${GITHUB_SHA::10}
+        run: apptainer push hippo-dev.sif oras://quay.io/ukaea/hippo:dev-${{ matrix.mpi }}-of${{ matrix.openfoam_version }}-${GITHUB_SHA::10}

--- a/.github/workflows/deploy-apptainer-dev.yml
+++ b/.github/workflows/deploy-apptainer-dev.yml
@@ -11,6 +11,9 @@ jobs:
       github.actor == 'mattfalcone1997' ||
       github.actor == 'k-collie'
     runs-on: ubuntu-latest
+    matrix:
+      openfoam_version: [12, 13]
+      mpi: [openmpi, mpich]
     steps:
       - uses: actions/checkout@v6
       - name: Install apptainer
@@ -19,7 +22,9 @@ jobs:
           sudo apt install -y ./apptainer_1.4.5_amd64.deb
       - name: Login to remote
         run: apptainer registry login -u ${{ secrets.QUAY_ID }} -p ${{ secrets.QUAY_TOKEN }} oras://quay.io
+      - name: Substitute container
+        run: MPI=${{ matrix.mpi }}  envsubst '${MPI}' < apptainer/hippo_dev.def.in > apptainer/hippo_dev.def
       - name: build container
-        run: apptainer build hippo-dev.sif apptainer/hippo-dev.def
+        run: apptainer build --build-arg OPENFOAM_VERSION=${{ matrix.openfoam_version }} hippo-dev.sif apptainer/hippo-dev.def
       - name: push container
-        run: apptainer push hippo-dev.sif oras://quay.io/ukaea/hippo:dev-${GITHUB_SHA::10}
+        run: apptainer push hippo-dev.sif oras://quay.io/ukaea/hippo_${{ matrix.mpi }}_OF${{ matrix.openfoam_version }}:dev-${GITHUB_SHA::10}

--- a/.github/workflows/deploy-apptainer-dev.yml
+++ b/.github/workflows/deploy-apptainer-dev.yml
@@ -11,9 +11,10 @@ jobs:
       github.actor == 'mattfalcone1997' ||
       github.actor == 'k-collie'
     runs-on: ubuntu-latest
-    matrix:
-      openfoam_version: [13, 14]
-      mpi: [openmpi, mpich]
+    strategy:
+      matrix:
+        openfoam_version: [13, 14]
+        mpi: [openmpi, mpich]
     steps:
       - uses: actions/checkout@v6
       - name: Install apptainer

--- a/.gitignore
+++ b/.gitignore
@@ -278,3 +278,6 @@ conf_vars.mk
 #OpenFOAM wmake build files
 **/lnInclude
 **/Make/linux*
+
+#apptainer definition files
+*.def

--- a/apptainer/hippo-dev.def.in
+++ b/apptainer/hippo-dev.def.in
@@ -92,7 +92,7 @@ From: ghcr.io/idaholab/apptainer/moose-dev-${MPI}-x86_64:2026.03.19
     ./scripts/install-openfoam.sh -o /opt/openfoam -s -j {{ OPENFOAM_JOBS }} -q -v {{ OPENFOAM_VERSION }}
 
     # So that prefs can be found when not run as root
-    cp /root/.OpenFOAM/prefs.sh /opt/openfoam/OpenFOAM-12/etc
+    cp /root/.OpenFOAM/prefs.sh /opt/openfoam/OpenFOAM-{{ OPENFOAM_VERSION }}/etc
 
     echo 'export MPI_ROOT=/opt/${MPI}' >> /opt/openfoam/OpenFOAM-{{ OPENFOAM_VERSION }}/etc/prefs.sh
     echo 'export MPI_ARCH_FLAGS="-DOMPI_SKIP_MPICXX"' >> /opt/openfoam/OpenFOAM-{{ OPENFOAM_VERSION }}/etc/prefs.sh

--- a/apptainer/hippo-dev.def.in
+++ b/apptainer/hippo-dev.def.in
@@ -3,7 +3,7 @@ From: ghcr.io/idaholab/apptainer/moose-dev-${MPI}-x86_64:2026.03.19
 
 %arguments
     MOOSE_JOBS=4
-    OPENFOAM_JOBS=4
+    OPENFOAM_JOBS=0
     OPENFOAM_VERSION=12
 
 %files

--- a/apptainer/hippo-dev.def.in
+++ b/apptainer/hippo-dev.def.in
@@ -23,7 +23,6 @@ From: ghcr.io/idaholab/apptainer/moose-dev-${MPI}-x86_64:2026.03.19
 
     dnf --enablerepo=devel install -y \
         findutils \
-        flex \
         git \
         glibc-devel \
         glibc-headers \
@@ -79,6 +78,7 @@ From: ghcr.io/idaholab/apptainer/moose-dev-${MPI}-x86_64:2026.03.19
     git checkout -d d41b47a41b7edac3875e308fb77df6069de32269
 
     conda install pyyaml jinja2 --yes --quiet
+    conda install -c conda-forge flex>=2.6.4 bison --yes --quiet
 
     make -C "${MOOSE_DIR}/modules/heat_transfer" -j {{ MOOSE_JOBS }} METHOD=opt
     make -C "${MOOSE_DIR}/modules/heat_transfer" -j {{ MOOSE_JOBS }} METHOD=dbg

--- a/apptainer/hippo-dev.def.in
+++ b/apptainer/hippo-dev.def.in
@@ -7,6 +7,7 @@ From: ghcr.io/idaholab/apptainer/moose-dev-${MPI}-x86_64:2026.03.19
     OPENFOAM_VERSION=12
 
 %files
+    ./scripts/install-findutils.sh /opt/hippo/scripts/install-findutils.sh
     ./scripts/install-openfoam.sh /opt/hippo/scripts/install-openfoam.sh
     ./scripts/openfoam.patch /opt/hippo/scripts/openfoam.patch
     ./requirements.test.txt /opt/hippo/
@@ -36,6 +37,11 @@ From: ghcr.io/idaholab/apptainer/moose-dev-${MPI}-x86_64:2026.03.19
         zlib-devel
 
     dnf clean all
+
+    # OpenFOAM CleanFunctions uses comma-separated arguments to find's -type,
+    # which are not supported by Rocky 8's findutils 4.6.
+    bash /opt/hippo/scripts/install-findutils.sh
+    hash -r
 
     # MOOSE
     export MOOSE_DIR=/opt/moose
@@ -105,6 +111,7 @@ From: ghcr.io/idaholab/apptainer/moose-dev-${MPI}-x86_64:2026.03.19
     conda install --file /opt/hippo/requirements.test.txt -S --yes --quiet
 
 %environment
+    export PATH=/usr/local/bin:$PATH
     . /opt/openfoam/OpenFOAM-{{ OPENFOAM_VERSION }}/etc/bashrc
     unset FOAM_SIGFPE
     export MOOSE_DIR=/opt/moose

--- a/apptainer/hippo-dev.def.in
+++ b/apptainer/hippo-dev.def.in
@@ -1,9 +1,10 @@
 Bootstrap: oras
-From: ghcr.io/idaholab/apptainer/moose-dev-openmpi-x86_64:2026.03.19
+From: ghcr.io/idaholab/apptainer/moose-dev-${MPI}-x86_64:2026.03.19
 
 %arguments
     MOOSE_JOBS=4
     OPENFOAM_JOBS=4
+    OPENFOAM_VERSION=12
 
 %files
     ./scripts/install-openfoam.sh /opt/hippo/scripts/install-openfoam.sh
@@ -46,16 +47,16 @@ From: ghcr.io/idaholab/apptainer/moose-dev-openmpi-x86_64:2026.03.19
     export VTKLIB_DIR=/opt/vtk/lib
 
     # MPI
-    export MPI_ROOT=/opt/openmpi
-    export MPI_ARCH_INC="-I/opt/openmpi/include"
-    export MPI_ARCH_LIBS="-L/opt/openmpi/lib -lmpi"
+    export MPI_ROOT=/opt/${MPI}
+    export MPI_ARCH_INC="-I/opt/${MPI}/include"
+    export MPI_ARCH_LIBS="-L/opt/${MPI}/lib -lmpi"
     export LD_LIBRARY_PATH="${MPI_ROOT}/lib:${LD_LIBRARY_PATH}"
     export PATH="${MPI_ROOT}/bin:${PATH}"
     # Compiler
-    export CC=/opt/openmpi/bin/mpicc
-    export CXX=/opt/openmpi/bin/mpicxx
-    export F77=/opt/openmpi/bin/mpif77
-    export F90=/opt/openmpi/bin/mpif90
+    export CC=/opt/${MPI}/bin/mpicc
+    export CXX=/opt/${MPI}/bin/mpicxx
+    export F77=/opt/${MPI}/bin/mpif77
+    export F90=/opt/${MPI}/bin/mpif90
     export PATH="/opt/rh/gcc-toolset-12/root/usr/bin:${PATH}"
     export CPLUS_INCLUDE_PATH="/opt/rh/gcc-toolset-12/root/usr/include/c++/12:${CPLUS_INCLUDE_PATH}"
     export LD_LIBRARY_PATH="/opt/rh/gcc-toolset-12/root/usr/lib64:/opt/rh/gcc-toolset-12/root/usr/lib:${LD_LIBRARY_PATH}"
@@ -88,22 +89,22 @@ From: ghcr.io/idaholab/apptainer/moose-dev-openmpi-x86_64:2026.03.19
     ln -s "${MPI_ROOT}/lib" "${MPI_ROOT}/lib64"
 
     cd /opt/hippo
-    ./scripts/install-openfoam.sh -o /opt/openfoam -s -j {{ OPENFOAM_JOBS }} -q
+    ./scripts/install-openfoam.sh -o /opt/openfoam -s -j {{ OPENFOAM_JOBS }} -q -v {{ OPENFOAM_VERSION }}
 
     # So that prefs can be found when not run as root
     cp /root/.OpenFOAM/prefs.sh /opt/openfoam/OpenFOAM-12/etc
 
-    echo 'export MPI_ROOT=/opt/openmpi' >> /opt/openfoam/OpenFOAM-12/etc/prefs.sh
-    echo 'export MPI_ARCH_FLAGS="-DOMPI_SKIP_MPICXX"' >> /opt/openfoam/OpenFOAM-12/etc/prefs.sh
-    echo 'export MPI_ARCH_INC="-isystem $MPI_ROOT/include"' >> /opt/openfoam/OpenFOAM-12/etc/prefs.sh
-    echo 'export MPI_ARCH_LIBS="-L$MPI_ROOT/lib -lmpi"' >> /opt/openfoam/OpenFOAM-12/etc/prefs.sh
+    echo 'export MPI_ROOT=/opt/${MPI}' >> /opt/openfoam/OpenFOAM-{{ OPENFOAM_VERSION }}/etc/prefs.sh
+    echo 'export MPI_ARCH_FLAGS="-DOMPI_SKIP_MPICXX"' >> /opt/openfoam/OpenFOAM-{{ OPENFOAM_VERSION }}/etc/prefs.sh
+    echo 'export MPI_ARCH_INC="-isystem $MPI_ROOT/include"' >> /opt/openfoam/OpenFOAM-{{ OPENFOAM_VERSION }}/etc/prefs.sh
+    echo 'export MPI_ARCH_LIBS="-L$MPI_ROOT/lib -lmpi"' >> /opt/openfoam/OpenFOAM-{{ OPENFOAM_VERSION }}/etc/prefs.sh
 
     # Ensure base OpenFOAM directory is correct when bashrc is sourced in future
-    sed -i 's|export FOAM_INST_DIR=\$HOME/\$WM_PROJECT|export FOAM_INST_DIR=/opt/openfoam|' /opt/openfoam/OpenFOAM-12/etc/bashrc
+    sed -i 's|export FOAM_INST_DIR=\$HOME/\$WM_PROJECT|export FOAM_INST_DIR=/opt/openfoam|' /opt/openfoam/OpenFOAM-{{ OPENFOAM_VERSION }}/etc/bashrc
 
     conda install --file /opt/hippo/requirements.test.txt -S --yes --quiet
 
 %environment
-    . /opt/openfoam/OpenFOAM-12/etc/bashrc
+    . /opt/openfoam/OpenFOAM-{{ OPENFOAM_VERSION }}/etc/bashrc
     unset FOAM_SIGFPE
     export MOOSE_DIR=/opt/moose

--- a/apptainer/hippo-dev.def.in
+++ b/apptainer/hippo-dev.def.in
@@ -115,3 +115,15 @@ From: ghcr.io/idaholab/apptainer/moose-dev-${MPI}-x86_64:2026.03.19
     . /opt/openfoam/OpenFOAM-{{ OPENFOAM_VERSION }}/etc/bashrc
     unset FOAM_SIGFPE
     export MOOSE_DIR=/opt/moose
+
+%test
+    set -eu
+
+    # Exercise the find syntax required by OpenFOAM's CleanFunctions.
+    find /tmp -maxdepth 0 -type f,l -print > /dev/null
+
+    # Check that core OpenFOAM utilities can be found and loaded.
+    for utility in blockMesh decomposePar foamRun; do
+        command -v "${utility}" > /dev/null
+        "${utility}" -help > /dev/null 2>&1
+    done

--- a/apptainer/hippo-release.def.in
+++ b/apptainer/hippo-release.def.in
@@ -1,5 +1,5 @@
 Bootstrap: oras
-From: quay.io/ukaea/hippo:dev-4f60782085
+From: quay.io/ukaea/hippo_${MPI}_OF${OPENFOAM_VERSION}:dev-4f60782085
 
 %files
     .git /opt/hippo/.git
@@ -20,12 +20,11 @@ From: quay.io/ukaea/hippo:dev-4f60782085
     MINIMAL=1
 
 %post
-    export MPI_ROOT=/opt/openmpi
     export MOOSE_DIR=/opt/moose
 
-    source /opt/openfoam/OpenFOAM-12/etc/bashrc || true
-    export FOAM_USER_LIBBIN=/root/OpenFOAM-12/lib
-    export FOAM_USER_APPBIN=/root/OpenFOAM-12/bin
+    source /opt/openfoam/OpenFOAM-${OPENFOAM_VERSION}/etc/bashrc || true
+    export FOAM_USER_LIBBIN=/root/OpenFOAM-${OPENFOAM_VERSION}/lib
+    export FOAM_USER_APPBIN=/root/OpenFOAM-${OPENFOAM_VERSION}/bin
 
     cd /opt/hippo/
     # Restore git repository to pristine state - useful for building locally
@@ -49,8 +48,8 @@ From: quay.io/ukaea/hippo:dev-4f60782085
     fi
 
     source /opt/openfoam/OpenFOAM-12/etc/bashrc
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/root/OpenFOAM-12/lib/
-    export PATH=$PATH:/root/OpenFOAM-12/bin/
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/root/OpenFOAM-${OPENFOAM_VERSION}/lib/
+    export PATH=$PATH:/root/OpenFOAM-${OPENFOAM_VERSION}/bin/
     unset FOAM_SIGFPE
     export PMIX_MCA_gds=hash
 

--- a/apptainer/hippo-release.def.in
+++ b/apptainer/hippo-release.def.in
@@ -1,5 +1,5 @@
 Bootstrap: oras
-From: quay.io/ukaea/hippo_${MPI}_OF${OPENFOAM_VERSION}:dev-4f60782085
+From: quay.io/ukaea/hippo_${MPI}_of${OPENFOAM_VERSION}:dev-4f60782085
 
 %files
     .git /opt/hippo/.git

--- a/scripts/install-findutils.sh
+++ b/scripts/install-findutils.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="4.10.0"
+prefix="/opt/findutils-${version}"
+build_dir="$(mktemp -d /tmp/findutils-build.XXXXXX)"
+
+cleanup()
+{
+    rm -rf "${build_dir}"
+}
+trap cleanup EXIT
+
+cd "${build_dir}"
+wget --quiet "https://ftp.gnu.org/gnu/findutils/findutils-${version}.tar.xz"
+tar -xf "findutils-${version}.tar.xz"
+cd "findutils-${version}"
+
+./configure \
+    --prefix="${prefix}" \
+    --disable-nls
+
+make -j"$(nproc)"
+make install
+
+mkdir -p /usr/local/bin
+ln -sfn "${prefix}/bin/find" /usr/local/bin/find
+
+# Verify the comma-separated type syntax used by OpenFOAM's CleanFunctions.
+/usr/local/bin/find --version
+/usr/local/bin/find /tmp -maxdepth 0 -type f,l -print

--- a/scripts/install-openfoam.sh
+++ b/scripts/install-openfoam.sh
@@ -7,6 +7,7 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 STRIP_SOURCES=0
 BUILD_JOBS=""
 QUIET_COMPILATION=0
+VERSION=12
 OUT_DIR="$(dirname "${SCRIPT_DIR}")/external/openfoam"
 USAGE="usage: install-openfoam.sh [-h] [-q] [-s] [-j JOBS] [-o DIRECTORY]
 
@@ -33,6 +34,7 @@ options:
                   hippo
   -j              set the number of build jobs, no limit by default. Pass 0 for
                   no limit
+  -v              Version of OpenFOAM to use
   -q              run compilations in silent/quiet mode
   -h              show help and exit
 "
@@ -45,10 +47,11 @@ for REQ in "${SCRIPT_REQUIREMENTS[@]}"; do
     fi
 done
 
-while getopts "o:j:sqh" opt; do
+while getopts "o:j:v:sqh" opt; do
     case "${opt}" in
         o) OUT_DIR="${OPTARG}" ;;
         j) BUILD_JOBS="${OPTARG}" ;;
+        v) VERSION="${OPTARG}" ;;
         s) STRIP_SOURCES=1 ;;
         q) QUIET_COMPILATION=1 ;;
         h) echo "${USAGE}" && exit 0 ;;
@@ -61,23 +64,23 @@ if [ "${BUILD_JOBS}" = "0" ]; then
     BUILD_JOBS=""
 fi;
 
-OPENFOAM_DIR="${OUT_DIR}/OpenFOAM-12"
-OPENFOAM_REV="9ec94dd57a8d98c3f3422ce9b2156a8b268bbda6"
-THIRDPARTY_DIR="${OUT_DIR}/ThirdParty-12"
-THIRDPARTY_REV="cab725f5e7929e8f5ec35c54edc493a822355235"
+OPENFOAM_DIR="${OUT_DIR}/OpenFOAM-${VERSION}"
+#OPENFOAM_REV="9ec94dd57a8d98c3f3422ce9b2156a8b268bbda6"
+THIRDPARTY_DIR="${OUT_DIR}/ThirdParty-${VERSION}"
+#THIRDPARTY_REV="cab725f5e7929e8f5ec35c54edc493a822355235"
 
 # Fetch and patch OpenFOAM
 mkdir -p "${OPENFOAM_DIR}"
 if [ ! -d "${OPENFOAM_DIR}/.git" ]; then
-    git clone https://github.com/OpenFOAM/OpenFOAM-12.git "${OPENFOAM_DIR}"
+    git clone --depth=1 https://github.com/OpenFOAM/OpenFOAM-${VERSION}.git "${OPENFOAM_DIR}"
 fi
-git -C "${OPENFOAM_DIR}" reset --hard "${OPENFOAM_REV}"
+#git -C "${OPENFOAM_DIR}" reset --hard "${OPENFOAM_REV}"
 git -C "${OPENFOAM_DIR}" apply "${SCRIPT_DIR}/openfoam.patch"
 
 # Set up OpenFOAM
 source "${OPENFOAM_DIR}/etc/bashrc" || true
 
-echo "Hippo installing OpenFOAM-12 with options:"
+echo "Hippo installing OpenFOAM-${VERSION} with options:"
 echo "------------------------------------------"
 echo "  WM_ARCH_OPTION:      ${WM_ARCH_OPTION}"
 echo "  WM_COMPILE_OPTION:   ${WM_COMPILE_OPTION}"
@@ -95,9 +98,9 @@ fi
 
 mkdir -p "${THIRDPARTY_DIR}"
 if [ ! -d "${THIRDPARTY_DIR}/.git" ]; then
-    git clone https://github.com/OpenFOAM/ThirdParty-12.git "${THIRDPARTY_DIR}"
+    git clone --depth=1 https://github.com/OpenFOAM/ThirdParty-${VERSION}.git "${THIRDPARTY_DIR}"
 fi
-git -C "${THIRDPARTY_DIR}" reset --hard "${THIRDPARTY_REV}"
+#git -C "${THIRDPARTY_DIR}" reset --hard "${THIRDPARTY_REV}"
 (
     cd "${THIRDPARTY_DIR}" \
     && ${ALLWMAKE}


### PR DESCRIPTION
## Summary

Use `envsubst` and `--build-arg` to allow different versions of MPI and OpenFOAM to be easily selected

## Related Issue

Resolves #128 

## Checklist

- [x] Tests have been written for the new/changed behaviour.
- [x] Documentation/examples have been added/updated for the new changes.
