### PR TITLE
Use tag to control version on OpenFOAM install script

### DIFF
--- a/apptainer/hippo-release.def
+++ b/apptainer/hippo-release.def
@@ -1,5 +1,5 @@
 Bootstrap: oras
-From: quay.io/ukaea/hippo:dev-{{ MPI }}-of{{ OPENFOAM_VERSION }}-0ec4697e70
+From: quay.io/ukaea/hippo:dev-{{ MPI }}-of{{ OPENFOAM_VERSION }}-c65686e666
 
 %files
     .git /opt/hippo/.git

--- a/scripts/install-openfoam.sh
+++ b/scripts/install-openfoam.sh
@@ -70,7 +70,7 @@ THIRDPARTY_DIR="${OUT_DIR}/ThirdParty-${VERSION}"
 # Fetch and patch OpenFOAM
 mkdir -p "${OPENFOAM_DIR}"
 if [ ! -d "${OPENFOAM_DIR}/.git" ]; then
-    git clone --depth=1 https://github.com/OpenFOAM/OpenFOAM-${VERSION}.git "${OPENFOAM_DIR}"
+    git clone --depth=1 -b version-${VERSION} https://github.com/OpenFOAM/OpenFOAM-${VERSION}.git "${OPENFOAM_DIR}"
 fi
 git -C "${OPENFOAM_DIR}" apply "${SCRIPT_DIR}/openfoam.patch"
 
@@ -95,7 +95,7 @@ fi
 
 mkdir -p "${THIRDPARTY_DIR}"
 if [ ! -d "${THIRDPARTY_DIR}/.git" ]; then
-    git clone --depth=1 https://github.com/OpenFOAM/ThirdParty-${VERSION}.git "${THIRDPARTY_DIR}"
+    git clone --depth=1 -b version-${VERSION} https://github.com/OpenFOAM/ThirdParty-${VERSION}.git "${THIRDPARTY_DIR}"
 fi
 (
     cd "${THIRDPARTY_DIR}" \


### PR DESCRIPTION
## Summary

Uses specific tag rather than default branch when installing OpenFOAM
## Related Issue

## Checklist

- [ ] Dev container builds
- [ ] Existing CI tests pass with new container
