### PR TITLE
Remove dependence on external tests for fixed-point restart test

### DIFF
--- a/test/tests/fixed-point/restart_heated_plate/tests
+++ b/test/tests/fixed-point/restart_heated_plate/tests
@@ -4,9 +4,21 @@
             type = RunCommand
             command = 'bash -c "foamCleanCase -case fluid-openfoam && blockMesh -case fluid-openfoam && decomposePar -case fluid-openfoam"'
         []
-        [first]
+        [run_reference]
             type = RunApp
             prereq = heated_plate_restart/setup
+            input = heated_plate.i
+            min_parallel = 4
+            max_parallel = 4
+        []
+        [copy_reference]
+            type = RunCommand
+            command = 'bash -c "reconstructPar -case fluid-openfoam && mkdir -p gold && cp -r fluid-openfoam heated_plate_out.e gold/"'
+            prereq = heated_plate_restart/run_reference
+        []
+        [first]
+            type = RunApp
+            prereq = heated_plate_restart/copy_reference
             input = heated_plate.i
             cli_args = '--test-checkpoint-half-transient'
             min_parallel = 4
@@ -19,7 +31,6 @@
             cli_args = '--recover heated_plate_out_cp/LATEST'
             delete_output_before_running = false
             exodiff = heated_plate_out.e
-            gold_dir = '../heated_plate_converge'
             min_parallel=4
             max_parallel=4
         []
@@ -32,6 +43,11 @@
             type = PythonUnitTest
             input = test.py
             prereq = heated_plate_restart/prep_verify
+        []
+        [clean]
+            type = RunCommand
+            command = 'bash -c "rm -rf gold"'
+            prereq = 'heated_plate_restart/verify'
         []
     []
 []

--- a/test/tests/fixed-point/restart_heated_plate/tests
+++ b/test/tests/fixed-point/restart_heated_plate/tests
@@ -1,8 +1,9 @@
 [Tests]
     [heated_plate_restart]
+        requirement = "Test the cases using fixed-point iteration restart correctly"
         [setup]
             type = RunCommand
-            command = 'bash -c "foamCleanCase -case fluid-openfoam && blockMesh -case fluid-openfoam && decomposePar -case fluid-openfoam"'
+            command = 'bash -c "foamCleanCase -case fluid-openfoam && rm -rf gold && blockMesh -case fluid-openfoam && decomposePar -case fluid-openfoam"'
         []
         [run_reference]
             type = RunApp


### PR DESCRIPTION
## Summary

Run reference case within the restart test `tests`. Currently, there is a potential race condition where the restart test depends on the  `heated_plate_converge` case having finished. While this has not caused an error yet to my knowledge, it certainly is possible

## Checklist

- [x] Tests pass
